### PR TITLE
发牌姬宝箱怪遗言修复

### DIFF
--- a/ai_festival_202408/chest12.lua
+++ b/ai_festival_202408/chest12.lua
@@ -13,14 +13,14 @@ function CHEST.EffectMessageAbsolute(e,rp)
     local name=CUNGUI.GetPlayerName()
     local name2=CUNGUI.GetAIName()
     if rp == CUNGUI.AI then name2,name = name,name2 end
-    local c=Duel.CreateToken(1-rp,21208154)
     if Duel.GetMZoneCount(1-rp)<1
-        or not Duel.IsCanBeSpecialSummoned(c,0,1-rp,true,true) then return "然而，场上似乎并没有什么变化……" end
+        or not Duel.IsPlayerCanSpecialSummonMonster(1-rp,21208154,0,TYPE_MONSTER+TYPE_EFFECT,-2,-2,10,RACE_FIEND,ATTRIBUTE_DARK) then return "然而，场上似乎并没有什么变化……" end
     return name2 .. "的场上似乎变黑了！"
 end
 
 --战斗破坏时发动的效果。
 function CHEST.BattleDestroyedEffect(e,rp)
+    if not Duel.IsPlayerCanSpecialSummonMonster(1-rp,21208154,0,TYPE_MONSTER+TYPE_EFFECT,-2,-2,10,RACE_FIEND,ATTRIBUTE_DARK) then return end
     while Duel.GetMZoneCount(1-rp)>0 do
         local c=Duel.CreateToken(1-rp,21208154)
         if Duel.SpecialSummonStep(c,0,1-rp,1-rp,true,true,POS_FACEUP_ATTACK)<1 then

--- a/ai_festival_202408/chest16.lua
+++ b/ai_festival_202408/chest16.lua
@@ -22,7 +22,7 @@ end
 
 function CHEST.filter(c,e,tp)
     return c:IsCanBeSpecialSummoned(e,0,tp,true,true)
-        and Duel.GetLocationCountFromEx(rp,rp,nil,c)>0
+        and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0
 end
 
 --战斗破坏时发动的效果。

--- a/ai_festival_202408/chest18.lua
+++ b/ai_festival_202408/chest18.lua
@@ -13,7 +13,7 @@ function CHEST.EffectMessageAbsolute(e,rp)
     local name=CUNGUI.GetPlayerName()
     local name2=CUNGUI.GetAIName()
     if rp == CUNGUI.AI then name2,name = name,name2 end
-    if Duel.GetFieldGroupCount(rp,LOCATION_MZONE)<1 then
+    if Duel.GetFieldGroupCount(rp,LOCATION_MZONE,0)<1 then
         return "但" .. name .. "不喜欢打打杀杀的……"
     end
     return name .. "给自己场上的怪兽装备了最强之剑！"

--- a/ai_festival_202408/chest25.lua
+++ b/ai_festival_202408/chest25.lua
@@ -13,7 +13,7 @@ function CHEST.EffectMessageAbsolute(e,rp)
     local name=CUNGUI.GetPlayerName()
     local name2=CUNGUI.GetAIName()
     if rp == CUNGUI.AI then name2,name = name,name2 end
-    if Duel.GetFieldGroup(1-rp,LOCATION_DECK,0)<1 then
+    if Duel.GetFieldGroupCount(1-rp,LOCATION_DECK,0)<1 then
         return "然而似乎没什么可破坏的了……"
     end
     return name2 .. "的卡组被破坏了！"

--- a/ai_festival_202408/chest43.lua
+++ b/ai_festival_202408/chest43.lua
@@ -13,7 +13,7 @@ function CHEST.EffectMessageAbsolute(e,rp)
     local name=CUNGUI.GetPlayerName()
     local name2=CUNGUI.GetAIName()
     if rp == CUNGUI.AI then name2,name = name,name2 end
-    local c=Duel.CreateToken(rp,33396958)
+    local c=Duel.CreateToken(rp,33396948)
     if Duel.GetMZoneCount(rp)<5 or not c:IsCanBeSpecialSummoned(e,0,rp,true,true) then
         return name .. "看了一场很有趣的演出，但并没有什么卵用。"
     end
@@ -23,7 +23,7 @@ end
 --战斗破坏时发动的效果。
 function CHEST.BattleDestroyedEffect(e,rp)
     if Duel.GetMZoneCount(rp)<5 then return end
-    for i in {33396958,8124921,44519536,70903634,7902349} do
+    for i in {33396948,8124921,44519536,70903634,7902349} do
         local c=Duel.CreateToken(rp,i)
         Duel.SpecialSummon(c,0,rp,rp,true,true,POS_FACEUP)
     end

--- a/ai_festival_202408/chest5.lua
+++ b/ai_festival_202408/chest5.lua
@@ -19,5 +19,5 @@ end
 
 --战斗破坏时发动的效果。
 function CHEST.BattleDestroyedEffect(e,rp)
-    Duel.Recover(1-rp,5000)
+    Duel.Recover(1-rp,5000,REASON_RULE)
 end

--- a/ai_festival_202408/chest52.lua
+++ b/ai_festival_202408/chest52.lua
@@ -13,7 +13,8 @@ CHEST.EffectMessage = "得到了可怕的力量！"
 
 --战斗破坏时发动的效果。
 function CHEST.BattleDestroyedEffect(e,rp)
-    for i in {55144522,55144522,55144522,55144522,55144522} do
+    local t = {55144522,55144522,55144522,55144522,55144522}
+    for _,i in ipairs(t) do
         local c=Duel.CreateToken(rp,i)
         Duel.SendtoHand(c,nil,REASON_RULE)
     end

--- a/ai_festival_202408/chest55.lua
+++ b/ai_festival_202408/chest55.lua
@@ -22,7 +22,7 @@ end
 function CHEST.BattleDestroyedEffect(e,rp)
     local g=Duel.GetFieldGroup(1-rp,LOCATION_ONFIELD,0)
     for tc in aux.Next(g) do
-		Duel.NegateRelatedChain(tc)
+		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
 		local e1=Effect.CreateEffect(tc)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DISABLE)

--- a/ai_festival_202408/chest57.lua
+++ b/ai_festival_202408/chest57.lua
@@ -27,7 +27,7 @@ end
 --战斗破坏时发动的效果。
 function CHEST.BattleDestroyedEffect(e,rp)
 	Duel.Hint(HINT_SELECTMSG,rp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(rp,c83764718.filter,rp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,rp)
+	local g=Duel.SelectMatchingCard(rp,Card.IsCanBeSpecialSummoned,rp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,0,rp,false,false)
     local tc=g:GetFirst()
     if aux.NecroValleyFilter()(tc) then
         Duel.SpecialSummon(tc,SUMMON_VALUE_MONSTER_REBORN,rp,rp,false,false,POS_FACEUP)

--- a/ai_festival_202408/chest65.lua
+++ b/ai_festival_202408/chest65.lua
@@ -23,7 +23,7 @@ end
 function CHEST.BattleDestroyedEffect(e,rp)
     local code=0
     local c=nil
-    for p in 0,1 do
+    for p = 0,1 do
         code=CUNGUI.GambleCards[math.random(#CUNGUI.GambleCards)]
         c=Duel.CreateToken(p,code)
         while Duel.SSet(p,c)>0 do

--- a/ai_festival_202408/chest66.lua
+++ b/ai_festival_202408/chest66.lua
@@ -15,7 +15,7 @@ function CHEST.EffectMessageAbsolute(e,rp)
     if rp == CUNGUI.AI then name2,name = name,name2 end
     local g=Duel.GetFieldGroupCount(rp,LOCATION_HAND,0)
     local g2=Duel.GetFieldGroupCount(1-rp,LOCATION_HAND,0)
-    if #g>=6 and #g2>=6 then return "但在场的人都是大富翁，没人愿意低头去捡钱……" end
+    if g>=6 and g2>=6 then return "但在场的人都是大富翁，没人愿意低头去捡钱……" end
     return "大家开始捡金币了！"
 end
 

--- a/ai_festival_202408/special-step1.lua
+++ b/ai_festival_202408/special-step1.lua
@@ -123,7 +123,7 @@ end
 
 CUNGUI.ChestEffectIndex=70 --待调整
 
-function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp)
+function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local ct=e:GetLabel()
 	if aux.GetValueType(ct)~="number" then ct=0 end

--- a/ai_festival_202408/special-step1.lua
+++ b/ai_festival_202408/special-step1.lua
@@ -96,25 +96,8 @@ function CUNGUI.CreateChestStep(tp)
 	e1:SetOperation(CUNGUI.chestop)
 	c:RegisterEffect(e1)
 
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_BATTLED)
-	e2:SetReset(RESET_EVENT+RESET_TOFIELD+RESET_MSCHANGE+RESET_TEMP_REMOVE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CAN_FORBIDDEN+EFFECT_FLAG_CANNOT_INACTIVATE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetOperation(CUNGUI.chestreg)
-	e2:SetLabelObject(e1)
-	c:RegisterEffect(e2)
-
 	table.insert(CUNGUI.Chests[tp],c)
 	return c
-end
-
-function CUNGUI.chestreg(e,tp)
-	local i=0
-	if Duel.GetAttacker()==e:GetHandler() then
-		i=1
-	end
-	e:GetLabelObject():SetLabel(i)
 end
 
 function CUNGUI.chestcond(e,tp,eg,ep,ev,re,r,rp)
@@ -125,16 +108,14 @@ CUNGUI.ChestEffectIndex=70 --待调整
 
 function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local ct=e:GetLabel()
-	if aux.GetValueType(ct)~="number" then ct=0 end
-	if ct==1 then rp = tp end
 	local i=math.random(CUNGUI.ChestEffectIndex)
-	e:SetLabel(ct,i)
+	e:SetLabel(i)
+	local p = Duel.GetAttacker():GetControler()
 	Duel.LoadScript("chest" .. tostring(i) .. ".lua")
 
 	if CHEST then
 		local name = CUNGUI.GetPlayerName()
-		if CUNGUI.AI == rp then
+		if CUNGUI.AI == p then
 			name = CUNGUI.GetAIName()
 		end
 		Debug.Message(name .. "狩猎了一个宝箱怪！")
@@ -143,7 +124,7 @@ function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 		elseif CHEST.Message then
 			Debug.Message(name .. "打开了宝箱，" .. CHEST.Message)
 		elseif CHEST.MessageAbsolute then
-			Debug.Message(CHEST.MessageAbsolute(rp))
+			Debug.Message(CHEST.MessageAbsolute(p))
 		end
 	end
 end
@@ -157,21 +138,21 @@ function CUNGUI.GetPlayerName()
 end
 
 function CUNGUI.chestop(e,tp,eg,ep,ev,re,r,rp)
-	local ct,i=e:GetLabel()
-	if ct==1 then rp = tp end
+	local i = e:GetLabel()
+	local p = Duel.GetAttacker():GetControler()
 	--对撞会同时触发2个，在这里要重新载入一次
 	Duel.LoadScript("chest" .. tostring(i) .. ".lua")
 	if CHEST and CHEST.BattleDestroyedEffect then
 		if CHEST.EffectMessage then
 			local name = CUNGUI.GetPlayerName()
-			if CUNGUI.AI == rp then
+			if CUNGUI.AI == p then
 				name = CUNGUI.GetAIName()
 			end
 			Debug.Message(name .. CHEST.EffectMessage)
 		elseif CHEST.EffectMessageAbsolute then
-			Debug.Message(CHEST.EffectMessageAbsolute(e,rp))
+			Debug.Message(CHEST.EffectMessageAbsolute(e,p))
 		end
-		CHEST.BattleDestroyedEffect(e,rp)
+		CHEST.BattleDestroyedEffect(e,p)
 	end
 	e:Reset()
 end

--- a/ai_festival_202408/special-step2.lua
+++ b/ai_festival_202408/special-step2.lua
@@ -207,16 +207,7 @@ function CUNGUI.CheckAI(e)
 			e1=e1:Clone()
 			Duel.RegisterEffect(e1,1)
 		end
-		if SP_RULE.RuleName then
-			Debug.Message("已启动规则：【" .. SP_RULE.RuleName .. "】，以下为规则详情。")
-		end
-		if SP_RULE.Message then
-			for _,v in pairs(SP_RULE.Message) do
-				Debug.Message(v)
-			end
-		else
-			Debug.Message("（详情不明）")
-		end
+		CUNGUI.HintRule()
 	end
 	e:Reset()
 end
@@ -238,6 +229,22 @@ function CUNGUI.HumanDraw(e,tp)
 	local c=Duel.CreateToken(tp,id)
     Duel.SendtoDeck(c,tp,SEQ_DECKTOP,REASON_RULE)
 	Duel.Draw(tp,1,REASON_RULE)
+	if tp ~= 0 or Duel.GetTurnCount(tp) > 1 then
+		CUNGUI.HintRule()
+	end
+end
+
+function CUNGUI.HintRule()
+	if SP_RULE.RuleName then
+		Debug.Message("已启动规则：【" .. SP_RULE.RuleName .. "】，以下为规则详情。")
+	end
+	if SP_RULE.Message then
+		for _,v in pairs(SP_RULE.Message) do
+			Debug.Message(v)
+		end
+	else
+		Debug.Message("（详情不明）")
+	end
 end
 
 function CUNGUI.RuleCardMove(e,tp)

--- a/ai_festival_202408/special-step2.lua
+++ b/ai_festival_202408/special-step2.lua
@@ -123,7 +123,7 @@ end
 
 CUNGUI.ChestEffectIndex=70 --待调整
 
-function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp)
+function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local ct=e:GetLabel()
 	if aux.GetValueType(ct)~="number" then ct=0 end

--- a/ai_festival_202408/special-step2.lua
+++ b/ai_festival_202408/special-step2.lua
@@ -96,25 +96,8 @@ function CUNGUI.CreateChestStep(tp)
 	e1:SetOperation(CUNGUI.chestop)
 	c:RegisterEffect(e1)
 
-	e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_BATTLED)
-	e2:SetReset(RESET_EVENT+RESET_TOFIELD+RESET_MSCHANGE+RESET_TEMP_REMOVE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CAN_FORBIDDEN+EFFECT_FLAG_CANNOT_INACTIVATE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetOperation(CUNGUI.chestreg)
-	e2:SetLabelObject(e1)
-	c:RegisterEffect(e2)
-
 	table.insert(CUNGUI.Chests[tp],c)
 	return c
-end
-
-function CUNGUI.chestreg(e,tp)
-	local i=0
-	if Duel.GetAttacker()==e:GetHandler() then
-		i=1
-	end
-	e:GetLabelObject():SetLabel(i)
 end
 
 function CUNGUI.chestcond(e,tp,eg,ep,ev,re,r,rp)
@@ -125,16 +108,14 @@ CUNGUI.ChestEffectIndex=70 --待调整
 
 function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local ct=e:GetLabel()
-	if aux.GetValueType(ct)~="number" then ct=0 end
-	if ct==1 then rp = tp end
 	local i=math.random(CUNGUI.ChestEffectIndex)
-	e:SetLabel(ct,i)
+	e:SetLabel(i)
+	local p = Duel.GetAttacker():GetControler()
 	Duel.LoadScript("chest" .. tostring(i) .. ".lua")
 
 	if CHEST then
 		local name = CUNGUI.GetPlayerName()
-		if CUNGUI.AI == rp then
+		if CUNGUI.AI == p then
 			name = CUNGUI.GetAIName()
 		end
 		Debug.Message(name .. "狩猎了一个宝箱怪！")
@@ -143,7 +124,7 @@ function CUNGUI.chesttg(e,tp,eg,ep,ev,re,r,rp,chk)
 		elseif CHEST.Message then
 			Debug.Message(name .. "打开了宝箱，" .. CHEST.Message)
 		elseif CHEST.MessageAbsolute then
-			Debug.Message(CHEST.MessageAbsolute(rp))
+			Debug.Message(CHEST.MessageAbsolute(p))
 		end
 	end
 end
@@ -157,21 +138,21 @@ function CUNGUI.GetPlayerName()
 end
 
 function CUNGUI.chestop(e,tp,eg,ep,ev,re,r,rp)
-	local ct,i=e:GetLabel()
-	if ct==1 then rp = tp end
+	local i = e:GetLabel()
+	local p = Duel.GetAttacker():GetControler()
 	--对撞会同时触发2个，在这里要重新载入一次
 	Duel.LoadScript("chest" .. tostring(i) .. ".lua")
 	if CHEST and CHEST.BattleDestroyedEffect then
 		if CHEST.EffectMessage then
 			local name = CUNGUI.GetPlayerName()
-			if CUNGUI.AI == rp then
+			if CUNGUI.AI == p then
 				name = CUNGUI.GetAIName()
 			end
 			Debug.Message(name .. CHEST.EffectMessage)
 		elseif CHEST.EffectMessageAbsolute then
-			Debug.Message(CHEST.EffectMessageAbsolute(e,rp))
+			Debug.Message(CHEST.EffectMessageAbsolute(e,p))
 		end
-		CHEST.BattleDestroyedEffect(e,rp)
+		CHEST.BattleDestroyedEffect(e,p)
 	end
 	e:Reset()
 end

--- a/wanning/special.lua
+++ b/wanning/special.lua
@@ -1470,8 +1470,7 @@ end)
 
 local function initialize()
   local skillCodes=getAllSkillCodes()
-  local res=Duel.TossCoin(0,1)
-  for tp=1-res, res, 2*res-1 do
+  for tp=0,1 do
     local codes={}
 	for _,code in ipairs(skillCodes) do
 		table.insert(codes,code)

--- a/wanning/special.lua
+++ b/wanning/special.lua
@@ -227,7 +227,7 @@ standbyPhaseSkill(69015963, function(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummonComplete()
 end, function(e,tp,eg,ep,ev,re,r,rp)
   return Duel.IsExistingMatchingCard(c69015963_filter,tp,LOCATION_EXTRA,0,1,nil,e,tp)
-end)
+end,true)
 
 --闪电风暴
 standbyPhaseSkill(14532163, function(e,tp,eg,ep,ev,re,r,rp)

--- a/wanning/special.lua
+++ b/wanning/special.lua
@@ -1329,6 +1329,12 @@ addSkill(48356796, function (e1)
 	end)
 end)
 
+oneTimeSkill(48356796, function (e,tp,eg,ep,ev,re,r,rp)
+	if (tp == 0) then
+		Duel.Draw(tp,5,REASON_RULE)
+	end
+end)
+
 addSkill(48356796, function (e2)
 	e2:SetType(EFFECT_TYPE_FIELD)
     e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
@@ -1337,7 +1343,7 @@ addSkill(48356796, function (e2)
     e2:SetValue(function (e)
 		local tp=e:GetHandlerPlayer()
 		local val=6
-		if Duel.GetFlagEffect(tp,19403423)>0 then val=7 end
+		if Duel.GetFlagEffect(tp,19403423)>0 then val=val+1 end
 		return val
 	end)
 end)


### PR DESCRIPTION
①：更改了原本使用setlabel判断rp的方法，改成了直接判断发起攻击的卡的控制者，将其作为狩猎宝箱怪的玩家
②：修复了大部分lua语法导致的报错