### PR TITLE
Revise 遺言状

### DIFF
--- a/overlay-free/c85602018.lua
+++ b/overlay-free/c85602018.lua
@@ -1,6 +1,10 @@
 --遺言状
 local s,id,o=GetID()
 function s.initial_effect(c)
+    -- Flags Used:
+    -- - id: Tracks graveyard events per player.
+    -- - id+o: Tracks special summon events per player.
+    -- - id+o*2: Tracks how many times the continuous effect is registered.
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)


### PR DESCRIPTION
Revise 遺言状 base on user request.

* Now it's Ash-able no matter we have monster sent to GY already or not.
* One SS oppotunity per 遺言状 per monster send to GY this turn.
