### PR TITLE
706服融合召唤、守墓侦察者、六武荒行及天抽、黑羽宝札还原调整

### DIFF
--- a/706/c12071500.lua
+++ b/706/c12071500.lua
@@ -1,0 +1,99 @@
+-- ダーク・コーリング
+function c12071500.initial_effect(c)
+    aux.AddCodeList(c, 94820406)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c12071500.target)
+    e1:SetOperation(c12071500.activate)
+    c:RegisterEffect(e1)
+end
+function c12071500.filter0(c)
+    return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove()
+end
+function c12071500.filter1(c, e)
+    return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c12071500.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c.dark_calling and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_VALUE_DARK_FUSION, tp, false, false) and
+               c:CheckFusionMaterial(m, nil, chkf)
+end
+function c12071500.filter3(c)
+    return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c12071500.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp):Filter(c12071500.filter0, nil)
+        local mg2 = Duel.GetMatchingGroup(c12071500.filter3, tp, LOCATION_GRAVE, 0, nil)
+        mg1:Merge(mg2)
+        local res = Duel.IsExistingMatchingCard(c12071500.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg3 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c12071500.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg3, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+    Duel.SetOperationInfo(0, CATEGORY_REMOVE, nil, 2, tp, LOCATION_HAND + LOCATION_GRAVE)
+end
+function c12071500.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c12071500.filter1, nil, e)
+    local mg2 = Duel.GetMatchingGroup(c12071500.filter3, tp, LOCATION_GRAVE, 0, nil)
+    mg1:Merge(mg2)
+    local sg1 = Duel.GetMatchingGroup(c12071500.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg3 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg3 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c12071500.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg3, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.Remove(mat1, POS_FACEUP, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_VALUE_DARK_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg3, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2, SUMMON_VALUE_DARK_FUSION)
+        end
+        tc:CompleteProcedure()
+    else
+		if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+            local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND, 0)
+            local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+            local ct = cg1:GetCount()
+            ct = ct + Duel.GetMatchingGroupCount(Card.IsType, tp, LOCATION_GRAVE, 0, nil, TYPE_MONSTER)
+            if ct > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+                not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+                Duel.ConfirmCards(1 - tp, cg1)
+                Duel.ConfirmCards(1 - tp, cg2)
+                Duel.ShuffleHand(tp)
+            end
+        end
+    end
+end

--- a/706/c1264319.lua
+++ b/706/c1264319.lua
@@ -1,0 +1,116 @@
+-- ジェムナイト・フュージョン
+function c1264319.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetDescription(aux.Stringid(1264319, 0))
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c1264319.target)
+    e1:SetOperation(c1264319.activate)
+    c:RegisterEffect(e1)
+    -- salvage
+    local e2 = Effect.CreateEffect(c)
+    e2:SetCategory(CATEGORY_TOHAND)
+    e2:SetDescription(aux.Stringid(1264319, 1))
+    e2:SetType(EFFECT_TYPE_IGNITION)
+    e2:SetRange(LOCATION_GRAVE)
+    e2:SetCost(c1264319.thcost)
+    e2:SetTarget(c1264319.thtg)
+    e2:SetOperation(c1264319.thop)
+    c:RegisterEffect(e2)
+end
+function c1264319.filter1(c, e)
+    return not c:IsImmuneToEffect(e)
+end
+function c1264319.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsSetCard(0x1047) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c1264319.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp)
+        local res = Duel.IsExistingMatchingCard(c1264319.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res = Duel.IsExistingMatchingCard(c1264319.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c1264319.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c1264319.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c1264319.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c1264319.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.SendtoGrave(mat1, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+        local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end
+function c1264319.thfilter(c)
+    return c:IsSetCard(0x1047) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+end
+function c1264319.thcost(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return Duel.IsExistingMatchingCard(c1264319.thfilter, tp, LOCATION_GRAVE, 0, 1, nil)
+    end
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_REMOVE)
+    local g = Duel.SelectMatchingCard(tp, c1264319.thfilter, tp, LOCATION_GRAVE, 0, 1, 1, nil)
+    Duel.Remove(g, POS_FACEUP, REASON_COST)
+end
+function c1264319.thtg(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return e:GetHandler():IsAbleToHand()
+    end
+    Duel.SetOperationInfo(0, CATEGORY_TOHAND, e:GetHandler(), 1, 0, 0)
+end
+function c1264319.thop(e, tp, eg, ep, ev, re, r, rp)
+    local c = e:GetHandler()
+    if c:IsRelateToEffect(e) then
+        Duel.SendtoHand(c, nil, REASON_EFFECT)
+        Duel.ConfirmCards(1 - tp, c)
+    end
+end

--- a/706/c23299957.lua
+++ b/706/c23299957.lua
@@ -1,0 +1,105 @@
+-- ビークロイド・コネクション・ゾーン
+function c23299957.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c23299957.target)
+    e1:SetOperation(c23299957.activate)
+    c:RegisterEffect(e1)
+end
+function c23299957.filter1(c, e)
+    return not c:IsImmuneToEffect(e)
+end
+function c23299957.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsSetCard(0x1016) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c23299957.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp)
+        local res = Duel.IsExistingMatchingCard(c23299957.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c23299957.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c23299957.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c23299957.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c23299957.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c23299957.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.SendtoGrave(mat1, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+        local c = e:GetHandler()
+        local e1 = Effect.CreateEffect(c)
+        e1:SetType(EFFECT_TYPE_SINGLE)
+        e1:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+        e1:SetValue(1)
+        e1:SetReset(RESET_EVENT + RESETS_STANDARD)
+        tc:RegisterEffect(e1, true)
+        local e2 = Effect.CreateEffect(c)
+        e2:SetType(EFFECT_TYPE_SINGLE)
+        e2:SetCode(EFFECT_CANNOT_DISABLE)
+        e2:SetReset(RESET_EVENT + RESETS_STANDARD)
+        tc:RegisterEffect(e2, true)
+        local e3 = Effect.CreateEffect(c)
+        e3:SetType(EFFECT_TYPE_FIELD)
+        e3:SetCode(EFFECT_CANNOT_DISEFFECT)
+        e3:SetRange(LOCATION_MZONE)
+        e3:SetValue(c23299957.efilter)
+        e3:SetReset(RESET_EVENT + RESETS_STANDARD)
+        tc:RegisterEffect(e3, true)
+    else
+        local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end
+function c23299957.efilter(e, ct)
+    local te = Duel.GetChainInfo(ct, CHAININFO_TRIGGERING_EFFECT)
+    return te:GetHandler() == e:GetHandler()
+end

--- a/706/c24094653.lua
+++ b/706/c24094653.lua
@@ -1,0 +1,82 @@
+-- 融合
+function c24094653.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c24094653.target)
+    e1:SetOperation(c24094653.activate)
+    c:RegisterEffect(e1)
+end
+function c24094653.filter1(c, e)
+    return not c:IsImmuneToEffect(e)
+end
+function c24094653.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c24094653.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp)
+        local res = Duel.IsExistingMatchingCard(c24094653.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c24094653.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c24094653.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c24094653.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c24094653.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c24094653.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.SendtoGrave(mat1, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+        local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end

--- a/706/c24317029.lua
+++ b/706/c24317029.lua
@@ -1,0 +1,35 @@
+-- 墓守の偵察者
+function c24317029.initial_effect(c)
+    -- flip
+    local e1 = Effect.CreateEffect(c)
+    e1:SetDescription(aux.Stringid(24317029, 0))
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+    e1:SetType(EFFECT_TYPE_SINGLE + EFFECT_TYPE_FLIP)
+    e1:SetTarget(c24317029.target)
+    e1:SetOperation(c24317029.operation)
+    c:RegisterEffect(e1)
+end
+function c24317029.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return true
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_DECK)
+end
+function c24317029.filter(c, e, tp)
+    return c:IsAttackBelow(1500) and c:IsSetCard(0x2e) and c:IsCanBeSpecialSummoned(e, 0, tp, false, false)
+end
+function c24317029.operation(e, tp, eg, ep, ev, re, r, rp)
+    if Duel.GetLocationCount(tp, LOCATION_MZONE) <= 0 then
+        return
+    end
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+    local g = Duel.SelectMatchingCard(tp, c24317029.filter, tp, LOCATION_DECK, 0, 1, 1, nil, e, tp)
+    if g:GetCount() > 0 then
+        Duel.SpecialSummon(g, 0, tp, tp, false, false, POS_FACEUP)
+    elseif Duel.IsPlayerCanSpecialSummon(tp) then
+        local cg = Duel.GetFieldGroup(tp, LOCATION_DECK, 0)
+        Duel.ConfirmCards(1 - tp, cg)
+        Duel.ConfirmCards(tp, cg)
+        Duel.ShuffleDeck(tp)
+    end
+end

--- a/706/c27821104.lua
+++ b/706/c27821104.lua
@@ -1,0 +1,74 @@
+-- 六武衆の荒行
+---@param c Card
+function c27821104.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+    e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c27821104.target)
+    e1:SetOperation(c27821104.activate)
+    c:RegisterEffect(e1)
+end
+function c27821104.tfilter(c, atk, code, e, tp)
+    return c:IsSetCard(0x103d) and not c:IsCode(code) and c:IsAttack(atk) and
+               c:IsCanBeSpecialSummoned(e, 0, tp, false, false)
+end
+function c27821104.filter(c, e, tp)
+    return c:IsFaceup() and c:IsSetCard(0x103d) and
+               Duel.IsExistingMatchingCard(c27821104.tfilter, tp, LOCATION_DECK, 0, 1, nil, c:GetAttack(), c:GetCode(),
+            e, tp)
+end
+function c27821104.target(e, tp, eg, ep, ev, re, r, rp, chk, chkc)
+    if chkc then
+        return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c27821104.filter(chkc, e, tp)
+    end
+    if chk == 0 then
+        return Duel.GetLocationCount(tp, LOCATION_MZONE) > 0 and
+                   Duel.IsExistingTarget(c27821104.filter, tp, LOCATION_MZONE, 0, 1, nil, e, tp)
+    end
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_FACEUP)
+    local g = Duel.SelectTarget(tp, c27821104.filter, tp, LOCATION_MZONE, 0, 1, 1, nil, e, tp)
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_DECK)
+end
+function c27821104.activate(e, tp, eg, ep, ev, re, r, rp)
+    if Duel.GetLocationCount(tp, LOCATION_MZONE) <= 0 then
+        return
+    end
+    local tc = Duel.GetFirstTarget()
+    if not tc:IsRelateToEffect(e) or tc:IsFacedown() then
+        return
+    end
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+    local atk = tc:GetAttack()
+    local sg = Duel.SelectMatchingCard(tp, c27821104.tfilter, tp, LOCATION_DECK, 0, 1, 1, nil, atk, tc:GetCode(), e, tp)
+    if sg:GetCount() > 0 then
+        Duel.SpecialSummon(sg, 0, tp, tp, false, false, POS_FACEUP)
+    else
+        local atks_flag = false
+        atks = {200, 400, 500, 1000, 1300, 1400, 1500, 1600, 1700, 1800, 2100}
+        for k, v in pairs(atks) do
+            if v == atk then
+                atks_flag = true
+                break
+            end
+        end
+        if atks_flag then
+            local cg = Duel.GetFieldGroup(tp, LOCATION_DECK, 0)
+            Duel.ConfirmCards(tp, cg)
+            Duel.ShuffleDeck(tp)
+        end
+    end
+    local e1 = Effect.CreateEffect(e:GetHandler())
+    e1:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+    e1:SetRange(LOCATION_MZONE)
+    e1:SetCode(EVENT_PHASE + PHASE_END)
+    e1:SetOperation(c27821104.desop)
+    e1:SetReset(RESET_EVENT + RESETS_STANDARD + RESET_PHASE + PHASE_END)
+    e1:SetCountLimit(1)
+    tc:RegisterEffect(e1)
+end
+function c27821104.desop(e, tp, eg, ep, ev, re, r, rp)
+    Duel.Destroy(e:GetHandler(), REASON_EFFECT)
+end

--- a/706/c33550694.lua
+++ b/706/c33550694.lua
@@ -1,0 +1,91 @@
+-- フュージョン・ゲート
+function c33550694.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    c:RegisterEffect(e1)
+    -- fusion
+    local e2 = Effect.CreateEffect(c)
+    e2:SetDescription(aux.Stringid(33550694, 0))
+    e2:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e2:SetType(EFFECT_TYPE_IGNITION)
+    e2:SetRange(LOCATION_FZONE)
+    e2:SetProperty(EFFECT_FLAG_BOTH_SIDE)
+    e2:SetTarget(c33550694.target)
+    e2:SetOperation(c33550694.operation)
+    c:RegisterEffect(e2)
+end
+function c33550694.filter1(c, e)
+    return c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c33550694.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c33550694.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp):Filter(Card.IsAbleToRemove, nil)
+        local res = Duel.IsExistingMatchingCard(c33550694.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c33550694.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c33550694.operation(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c33550694.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c33550694.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c33550694.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.Remove(mat1, POS_FACEUP, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+		if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+			local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+			local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+			if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+				not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+				Duel.ConfirmCards(1 - tp, cg1)
+				Duel.ConfirmCards(1 - tp, cg2)
+				Duel.ShuffleHand(tp)
+			end
+		end
+    end
+end

--- a/706/c36484016.lua
+++ b/706/c36484016.lua
@@ -112,7 +112,6 @@ function c36484016.activate(e, tp, eg, ep, ev, re, r, rp)
                 not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
                 Duel.ConfirmCards(1 - tp, cg1)
                 Duel.ConfirmCards(1 - tp, cg2)
-                Duel.ShuffleHand(tp)
             end
         end
     end

--- a/706/c36484016.lua
+++ b/706/c36484016.lua
@@ -1,0 +1,137 @@
+-- ミラクルシンクロフュージョン
+---@param c Card
+function c36484016.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_REMOVE + CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c36484016.target)
+    e1:SetOperation(c36484016.activate)
+    c:RegisterEffect(e1)
+    -- draw
+    local e2 = Effect.CreateEffect(c)
+    e2:SetDescription(aux.Stringid(36484016, 1))
+    e2:SetCategory(CATEGORY_DRAW)
+    e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP + EFFECT_FLAG_PLAYER_TARGET)
+    e2:SetType(EFFECT_TYPE_SINGLE + EFFECT_TYPE_TRIGGER_F)
+    e2:SetCode(EVENT_TO_GRAVE)
+    e2:SetCondition(c36484016.drcon)
+    e2:SetTarget(c36484016.drtg)
+    e2:SetOperation(c36484016.drop)
+    c:RegisterEffect(e2)
+end
+function c36484016.filter0(c)
+    return c:IsOnField() and c:IsAbleToRemove()
+end
+function c36484016.filter1(c, e)
+    return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c36484016.filter2(c, e, tp, m, f, chkf)
+    if not (c:IsType(TYPE_FUSION) and aux.IsMaterialListType(c, TYPE_SYNCHRO) and (not f or f(c)) and
+        c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false)) then
+        return false
+    end
+    aux.FCheckAdditional = c.synchro_fusion_check or c36484016.fcheck
+    local res = c:CheckFusionMaterial(m, nil, chkf)
+    aux.FCheckAdditional = nil
+    return res
+end
+function c36484016.filter4(c)
+    return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c36484016.fcheck(tp, sg, fc)
+    return sg:IsExists(Card.IsFusionType, 1, nil, TYPE_SYNCHRO)
+end
+function c36484016.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp):Filter(c36484016.filter0, nil)
+        local mg2 = Duel.GetMatchingGroup(c36484016.filter4, tp, LOCATION_GRAVE, 0, nil)
+        mg1:Merge(mg2)
+        local res = Duel.IsExistingMatchingCard(c36484016.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg3 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c36484016.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg3, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+    Duel.SetOperationInfo(0, CATEGORY_REMOVE, nil, 1, tp, LOCATION_ONFIELD + LOCATION_GRAVE)
+end
+function c36484016.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c36484016.filter1, nil, e)
+    local mg2 = Duel.GetMatchingGroup(c36484016.filter4, tp, LOCATION_GRAVE, 0, nil)
+    mg1:Merge(mg2)
+    local sg1 = Duel.GetMatchingGroup(c36484016.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg3 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg3 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c36484016.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg3, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        aux.FCheckAdditional = tc.synchro_fusion_check or c36484016.fcheck
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.Remove(mat1, POS_FACEUP, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg3, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+        if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+            local cg1 = Duel.GetFieldGroup(tp, LOCATION_MZONE, 0)
+            local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+            local ct = cg1:GetCount()
+            ct = ct + Duel.GetMatchingGroupCount(Card.IsType, tp, LOCATION_GRAVE, 0, nil, TYPE_MONSTER)
+            if ct > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+                not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+                Duel.ConfirmCards(1 - tp, cg1)
+                Duel.ConfirmCards(1 - tp, cg2)
+                Duel.ShuffleHand(tp)
+            end
+        end
+    end
+    aux.FCheckAdditional = nil
+end
+function c36484016.drcon(e, tp, eg, ep, ev, re, r, rp)
+    local c = e:GetHandler()
+    return bit.band(r, 0x41) == 0x41 and rp == 1 - tp and c:IsPreviousControler(tp) and
+               c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEDOWN)
+end
+function c36484016.drtg(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return true
+    end
+    Duel.SetTargetPlayer(tp)
+    Duel.SetTargetParam(1)
+    Duel.SetOperationInfo(0, CATEGORY_DRAW, nil, 0, tp, 1)
+end
+function c36484016.drop(e, tp, eg, ep, ev, re, r, rp)
+    local p, d = Duel.GetChainInfo(0, CHAININFO_TARGET_PLAYER, CHAININFO_TARGET_PARAM)
+    Duel.Draw(p, d, REASON_EFFECT)
+end

--- a/706/c3659803.lua
+++ b/706/c3659803.lua
@@ -87,7 +87,6 @@ function c3659803.activate(e,tp,eg,ep,ev,re,r,rp)
                 not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
                 Duel.ConfirmCards(1 - tp, cg1)
                 Duel.ConfirmCards(1 - tp, cg2)
-                Duel.ShuffleHand(tp)
             end
         end
 	end

--- a/706/c3659803.lua
+++ b/706/c3659803.lua
@@ -1,0 +1,94 @@
+--オーバーロード・フュージョン
+---@param c Card
+function c3659803.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE+CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c3659803.target)
+	e1:SetOperation(c3659803.activate)
+	c:RegisterEffect(e1)
+end
+function c3659803.filter0(c)
+	return c:IsOnField() and c:IsAbleToRemove()
+end
+function c3659803.filter1(c,e)
+	return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c3659803.filter2(c,e,tp,m,f,chkf)
+	return c:IsType(TYPE_FUSION) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_MACHINE) and (not f or f(c))
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c3659803.filter3(c)
+	return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c3659803.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local chkf=tp
+		local mg1=Duel.GetFusionMaterial(tp):Filter(c3659803.filter0,nil)
+		local mg2=Duel.GetMatchingGroup(c3659803.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
+		local res=Duel.IsExistingMatchingCard(c3659803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		if not res then
+			local ce=Duel.GetChainMaterial(tp)
+			if ce~=nil then
+				local fgroup=ce:GetTarget()
+				local mg3=fgroup(ce,e,tp)
+				local mf=ce:GetValue()
+				res=Duel.IsExistingMatchingCard(c3659803.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+			end
+		end
+		return res
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,tp,LOCATION_ONFIELD+LOCATION_GRAVE)
+end
+function c3659803.activate(e,tp,eg,ep,ev,re,r,rp)
+	local chkf=tp
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c3659803.filter1,nil,e)
+	local mg2=Duel.GetMatchingGroup(c3659803.filter3,tp,LOCATION_GRAVE,0,nil)
+	mg1:Merge(mg2)
+	local sg1=Duel.GetMatchingGroup(c3659803.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg3=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg3=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		sg2=Duel.GetMatchingGroup(c3659803.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+	end
+	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.Remove(mat1,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+		else
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,chkf)
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2)
+		end
+		tc:CompleteProcedure()
+	else 
+		if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+            local cg1 = Duel.GetFieldGroup(tp, LOCATION_MZONE, 0)
+            local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+            local ct = cg1:GetCount()
+            ct = ct + Duel.GetMatchingGroupCount(Card.IsType, tp, LOCATION_GRAVE, 0, nil, TYPE_MONSTER)
+            if ct > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+                not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+                Duel.ConfirmCards(1 - tp, cg1)
+                Duel.ConfirmCards(1 - tp, cg2)
+                Duel.ShuffleHand(tp)
+            end
+        end
+	end
+end

--- a/706/c37630732.lua
+++ b/706/c37630732.lua
@@ -1,0 +1,101 @@
+-- パワー・ボンド
+function c37630732.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c37630732.target)
+    e1:SetOperation(c37630732.activate)
+    c:RegisterEffect(e1)
+end
+function c37630732.filter1(c, e)
+    return not c:IsImmuneToEffect(e)
+end
+function c37630732.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsRace(RACE_MACHINE) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c37630732.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp)
+        local res = Duel.IsExistingMatchingCard(c37630732.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c37630732.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c37630732.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c37630732.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c37630732.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c37630732.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.SendtoGrave(mat1, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+        local e1 = Effect.CreateEffect(e:GetHandler())
+        e1:SetType(EFFECT_TYPE_SINGLE)
+        e1:SetCode(EFFECT_UPDATE_ATTACK)
+        e1:SetValue(tc:GetBaseAttack())
+        e1:SetReset(RESET_EVENT + RESETS_STANDARD)
+        tc:RegisterEffect(e1, true)
+        if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+            local e2 = Effect.CreateEffect(e:GetHandler())
+            e2:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+            e2:SetCode(EVENT_PHASE + PHASE_END)
+            e2:SetCountLimit(1)
+            e2:SetLabel(tc:GetBaseAttack())
+            e2:SetReset(RESET_PHASE + PHASE_END)
+            e2:SetOperation(c37630732.damop)
+            Duel.RegisterEffect(e2, tp)
+        end
+    else
+        local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end
+function c37630732.damop(e, tp, eg, ep, ev, re, r, rp)
+    Duel.Damage(tp, e:GetLabel(), REASON_EFFECT)
+end

--- a/706/c39261576.lua
+++ b/706/c39261576.lua
@@ -95,7 +95,6 @@ function c39261576.activate(e,tp,eg,ep,ev,re,r,rp)
             not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
             Duel.ConfirmCards(1 - tp, cg1)
             Duel.ConfirmCards(1 - tp, cg2)
-            Duel.ShuffleHand(tp)
         end
 	end
 end

--- a/706/c39261576.lua
+++ b/706/c39261576.lua
@@ -1,0 +1,137 @@
+--パーティカル・フュージョン
+---@param c Card
+function c39261576.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c39261576.target)
+	e1:SetOperation(c39261576.activate)
+	c:RegisterEffect(e1)
+	--atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetDescription(aux.Stringid(39261576,0))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_CUSTOM+39261576)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(c39261576.atkcon)
+	e2:SetCost(c39261576.atkcost)
+	e2:SetTarget(c39261576.atktg)
+	e2:SetOperation(c39261576.atkop)
+	e2:SetLabelObject(e1)
+	c:RegisterEffect(e2)
+end
+function c39261576.filter1(c,e)
+	return c:IsOnField() and not c:IsImmuneToEffect(e)
+end
+function c39261576.filter2(c,e,tp,m,f,chkf)
+	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x1047) and (not f or f(c))
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function c39261576.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local chkf=tp
+		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsOnField,nil)
+		local res=Duel.IsExistingMatchingCard(c39261576.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		if not res then
+			local ce=Duel.GetChainMaterial(tp)
+			if ce~=nil then
+				local fgroup=ce:GetTarget()
+				local mg2=fgroup(ce,e,tp)
+				local mf=ce:GetValue()
+				res=Duel.IsExistingMatchingCard(c39261576.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,chkf)
+			end
+		end
+		return res
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c39261576.activate(e,tp,eg,ep,ev,re,r,rp)
+	local chkf=tp
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c39261576.filter1,nil,e)
+	local sg1=Duel.GetMatchingGroup(c39261576.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg2=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg2=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		sg2=Duel.GetMatchingGroup(c39261576.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+	end
+	if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+			e:SetLabelObject(tc)
+		else
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2)
+			e:SetLabelObject(tc)
+		end
+		tc:CompleteProcedure()
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_CHAIN_END)
+		e1:SetOperation(c39261576.evop)
+		e1:SetLabelObject(e)
+		Duel.RegisterEffect(e1,tp)
+	else 
+		local cg1 = Duel.GetFieldGroup(tp, LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+	end
+end
+function c39261576.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return re==e:GetLabelObject()
+end
+function c39261576.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() end
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+end
+function c39261576.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=eg:GetFirst()
+	local mat=tc:GetMaterial()
+	if chkc then return chkc:IsSetCard(0x1047) and mat:IsContains(chkc) end
+	if chk==0 then return mat:IsExists(Card.IsSetCard,1,nil,0x1047) end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(39261576,1))
+	local g=mat:FilterSelect(tp,Card.IsSetCard,1,1,nil,0x1047)
+	tc:CreateEffectRelation(e)
+	Duel.SetTargetCard(g)
+end
+function c39261576.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local sc=eg:GetFirst()
+	if not sc:IsRelateToEffect(e) or sc:IsFacedown() then return end
+	local tc=Duel.GetFirstTarget()
+	if not tc:IsRelateToEffect(e) then return end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(tc:GetAttack())
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+	sc:RegisterEffect(e1)
+end
+function c39261576.evop(e,tp,eg,ep,ev,re,r,rp)
+	local te=e:GetLabelObject()
+	local tc=te:GetLabelObject()
+	Duel.RaiseEvent(tc,EVENT_CUSTOM+39261576,te,0,tp,tp,0)
+	te:SetLabelObject(nil)
+	e:Reset()
+end

--- a/706/c4168871.lua
+++ b/706/c4168871.lua
@@ -1,0 +1,91 @@
+--黒羽の宝札
+---@param c Card
+function c4168871.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCountLimit(1,4168871+EFFECT_COUNT_CODE_OATH)
+	e1:SetCost(c4168871.cost)
+	e1:SetTarget(c4168871.target)
+	e1:SetOperation(c4168871.activate)
+	c:RegisterEffect(e1)
+	if not c4168871.global_check then
+        c4168871.global_check = true
+        c4168871[0] = false
+        c4168871[1] = false
+        local ge1 = Effect.CreateEffect(c)
+        ge1:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge1:SetCode(EVENT_SPSUMMON_NEGATED)
+        ge1:SetOperation(c4168871.checkop1)
+        Duel.RegisterEffect(ge1, 0)
+        local ge2 = Effect.CreateEffect(c)
+        ge2:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge2:SetCode(EVENT_CHAINING)
+        ge2:SetOperation(c4168871.checkop2)
+        Duel.RegisterEffect(ge2, 0)
+        local ge3 = Effect.CreateEffect(c)
+        ge3:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge3:SetCode(EVENT_CHAIN_NEGATED)
+        ge3:SetOperation(c4168871.checkop3)
+        Duel.RegisterEffect(ge3, 0)
+        local ge4 = Effect.CreateEffect(c)
+        ge4:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge4:SetCode(EVENT_TURN_END)
+        ge4:SetOperation(c4168871.clear)
+        Duel.RegisterEffect(ge4, 0)
+    end
+end
+function c4168871.checkop1(e, tp, eg, ep, ev, re, r, rp)
+    local tc = eg:GetFirst()
+    local turnp = Duel.GetTurnPlayer()
+    c4168871[turnp] = tc:IsControler(turnp)
+end
+function c4168871.checkop2(e, tp, eg, ep, ev, re, r, rp)
+    local turnp = Duel.GetTurnPlayer()
+    local ex = Duel.GetOperationInfo(ev, CATEGORY_SPECIAL_SUMMON)
+    if ex and rp == turnp then
+        c4168871[turnp] = true
+    end
+end
+function c4168871.checkop3(e, tp, eg, ep, ev, re, r, rp)
+    local turnp = Duel.GetTurnPlayer()
+    local ex = Duel.GetOperationInfo(ev, CATEGORY_SPECIAL_SUMMON)
+    if ex and rp == turnp then
+        c4168871[turnp] = false
+    end
+end
+function c4168871.clear(e, tp, eg, ep, ev, re, r, rp)
+    c4168871[0] = false
+    c4168871[1] = false
+end
+function c4168871.filter(c)
+	return c:IsSetCard(0x33) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+end
+function c4168871.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local turnp=Duel.GetTurnPlayer()
+	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_SPSUMMON)==0
+		and Duel.IsExistingMatchingCard(c4168871.filter,tp,LOCATION_HAND,0,1,nil) and not c4168871[turnp] end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c4168871.filter,tp,LOCATION_HAND,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetTargetRange(1,0)
+	Duel.RegisterEffect(e1,tp)
+end
+function c4168871.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(2)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
+end
+function c4168871.activate(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/706/c45906428.lua
+++ b/706/c45906428.lua
@@ -1,0 +1,98 @@
+-- ミラクル・フュージョン
+---@param c Card
+function c45906428.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_REMOVE + CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c45906428.target)
+    e1:SetOperation(c45906428.activate)
+    c:RegisterEffect(e1)
+end
+function c45906428.filter0(c)
+    return c:IsOnField() and c:IsAbleToRemove()
+end
+function c45906428.filter1(c, e)
+    return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c45906428.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsSetCard(0x3008) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c45906428.filter3(c)
+    return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c45906428.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp):Filter(c45906428.filter0, nil)
+        local mg2 = Duel.GetMatchingGroup(c45906428.filter3, tp, LOCATION_GRAVE, 0, nil)
+        mg1:Merge(mg2)
+        local res = Duel.IsExistingMatchingCard(c45906428.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg3 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c45906428.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg3, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+    Duel.SetOperationInfo(0, CATEGORY_REMOVE, nil, 1, tp, LOCATION_ONFIELD + LOCATION_GRAVE)
+end
+function c45906428.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c45906428.filter1, nil, e)
+    local mg2 = Duel.GetMatchingGroup(c45906428.filter3, tp, LOCATION_GRAVE, 0, nil)
+    mg1:Merge(mg2)
+    local sg1 = Duel.GetMatchingGroup(c45906428.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg3 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg3 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c45906428.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg3, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.Remove(mat1, POS_FACEUP, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg3, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+        if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+            local cg1 = Duel.GetFieldGroup(tp, LOCATION_MZONE, 0)
+            local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+            local ct = cg1:GetCount()
+            ct = ct + Duel.GetMatchingGroupCount(Card.IsType, tp, LOCATION_GRAVE, 0, nil, TYPE_MONSTER)
+            if ct > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+                not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+                Duel.ConfirmCards(1 - tp, cg1)
+                Duel.ConfirmCards(1 - tp, cg2)
+                Duel.ShuffleHand(tp)
+            end
+        end
+    end
+end

--- a/706/c45906428.lua
+++ b/706/c45906428.lua
@@ -91,7 +91,6 @@ function c45906428.activate(e, tp, eg, ep, ev, re, r, rp)
                 not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
                 Duel.ConfirmCards(1 - tp, cg1)
                 Duel.ConfirmCards(1 - tp, cg2)
-                Duel.ShuffleHand(tp)
             end
         end
     end

--- a/706/c49469105.lua
+++ b/706/c49469105.lua
@@ -1,0 +1,71 @@
+-- 融合破棄
+---@param c Card
+function c49469105.initial_effect(c)
+    -- spsummon
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetCost(c49469105.cost)
+    e1:SetTarget(c49469105.target)
+    e1:SetOperation(c49469105.operation)
+    c:RegisterEffect(e1)
+end
+function c49469105.cfilter(c)
+    return c:IsCode(24094653) and c:IsDiscardable() and c:IsAbleToGraveAsCost()
+end
+function c49469105.cost(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return Duel.IsExistingMatchingCard(c49469105.cfilter, tp, LOCATION_HAND, 0, 1, nil)
+    end
+    Duel.DiscardHand(tp, c49469105.cfilter, 1, 1, REASON_COST + REASON_DISCARD)
+end
+function c49469105.filter1(c, g)
+    return c:IsType(TYPE_FUSION) and g:IsExists(c49469105.filter2, 1, nil, c)
+end
+function c49469105.filter2(c, fc)
+    return aux.IsMaterialListCode(fc, c:GetCode())
+end
+function c49469105.spfilter(c, e, tp)
+    return c:IsCanBeSpecialSummoned(e, 0, tp, false, false)
+end
+function c49469105.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    local g = Duel.GetMatchingGroup(c49469105.spfilter, tp, LOCATION_HAND, 0, nil, e, tp)
+    if chk == 0 then
+        return Duel.GetLocationCount(tp, LOCATION_MZONE) > 0 and
+                   Duel.IsExistingMatchingCard(c49469105.filter1, tp, LOCATION_EXTRA, 0, 1, nil, g)
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_HAND)
+end
+function c49469105.operation(e, tp, eg, ep, ev, re, r, rp)
+    if Duel.GetLocationCount(tp, LOCATION_MZONE) <= 0 then
+        return
+    end
+    local g = Duel.GetMatchingGroup(c49469105.spfilter, tp, LOCATION_HAND, 0, nil, e, tp)
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_TOGRAVE)
+    local exg = Duel.SelectMatchingCard(tp, c49469105.filter1, tp, LOCATION_EXTRA, 0, 1, 1, nil, g)
+    if exg:GetCount() > 0 then
+        Duel.SendtoGrave(exg, REASON_EFFECT)
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local sg = g:FilterSelect(tp, c49469105.filter2, 1, 1, nil, exg:GetFirst())
+        Duel.SpecialSummon(sg, 0, tp, tp, false, false, POS_FACEUP)
+        local e1 = Effect.CreateEffect(e:GetHandler())
+        e1:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+        e1:SetRange(LOCATION_MZONE)
+        e1:SetCode(EVENT_PHASE + PHASE_END)
+        e1:SetOperation(c49469105.tgop)
+        e1:SetReset(RESET_EVENT + RESETS_STANDARD + RESET_PHASE + PHASE_END)
+        e1:SetCountLimit(1)
+        sg:GetFirst():RegisterEffect(e1, true)
+    else
+        local cg = Duel.GetFieldGroup(tp, LOCATION_HAND, 0)
+        if cg:GetCount() > 0 then
+            Duel.ConfirmCards(1 - tp, cg)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end
+function c49469105.tgop(e, tp, eg, ep, ev, re, r, rp)
+    Duel.SendtoGrave(e:GetHandler(), REASON_EFFECT)
+end

--- a/706/c54977057.lua
+++ b/706/c54977057.lua
@@ -1,0 +1,95 @@
+-- 天空の宝札
+---@param c Card
+function c54977057.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_DRAW + CATEGORY_REMOVE)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetCost(c54977057.cost)
+    e1:SetTarget(c54977057.target)
+    e1:SetOperation(c54977057.activate)
+    c:RegisterEffect(e1)
+    if not c54977057.global_check then
+        c54977057.global_check = true
+        c54977057[0] = false
+        c54977057[1] = false
+        local ge1 = Effect.CreateEffect(c)
+        ge1:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge1:SetCode(EVENT_SPSUMMON_NEGATED)
+        ge1:SetOperation(c54977057.checkop1)
+        Duel.RegisterEffect(ge1, 0)
+        local ge2 = Effect.CreateEffect(c)
+        ge2:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge2:SetCode(EVENT_CHAINING)
+        ge2:SetOperation(c54977057.checkop2)
+        Duel.RegisterEffect(ge2, 0)
+        local ge3 = Effect.CreateEffect(c)
+        ge3:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge3:SetCode(EVENT_CHAIN_NEGATED)
+        ge3:SetOperation(c54977057.checkop3)
+        Duel.RegisterEffect(ge3, 0)
+        local ge4 = Effect.CreateEffect(c)
+        ge4:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS)
+        ge4:SetCode(EVENT_TURN_END)
+        ge4:SetOperation(c54977057.clear)
+        Duel.RegisterEffect(ge4, 0)
+    end
+end
+function c54977057.checkop1(e, tp, eg, ep, ev, re, r, rp)
+    local tc = eg:GetFirst()
+    local turnp = Duel.GetTurnPlayer()
+    c54977057[turnp] = tc:IsControler(turnp)
+end
+function c54977057.checkop2(e, tp, eg, ep, ev, re, r, rp)
+    local turnp = Duel.GetTurnPlayer()
+    local ex = Duel.GetOperationInfo(ev, CATEGORY_SPECIAL_SUMMON)
+    if ex and rp == turnp then
+        c54977057[turnp] = true
+    end
+end
+function c54977057.checkop3(e, tp, eg, ep, ev, re, r, rp)
+    local turnp = Duel.GetTurnPlayer()
+    local ex = Duel.GetOperationInfo(ev, CATEGORY_SPECIAL_SUMMON)
+    if ex and rp == turnp then
+        c54977057[turnp] = false
+    end
+end
+function c54977057.clear(e, tp, eg, ep, ev, re, r, rp)
+    c54977057[0] = false
+    c54977057[1] = false
+end
+function c54977057.cost(e, tp, eg, ep, ev, re, r, rp, chk)
+	local turnp=Duel.GetTurnPlayer()
+    if chk == 0 then
+        return Duel.GetActivityCount(tp, ACTIVITY_SPSUMMON) == 0 and Duel.GetActivityCount(tp, ACTIVITY_BATTLE_PHASE) ==
+                   0 and not c54977057[turnp]
+    end
+    local e1 = Effect.CreateEffect(e:GetHandler())
+    e1:SetType(EFFECT_TYPE_FIELD)
+    e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET + EFFECT_FLAG_OATH)
+    e1:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+    e1:SetReset(RESET_PHASE + PHASE_END)
+    e1:SetTargetRange(1, 0)
+    Duel.RegisterEffect(e1, tp)
+    local e2 = e1:Clone()
+    e2:SetCode(EFFECT_CANNOT_BP)
+    Duel.RegisterEffect(e2, tp)
+end
+function c54977057.filter(c)
+    return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and c:IsAbleToRemove()
+end
+function c54977057.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return Duel.IsPlayerCanDraw(tp, 2) and
+                   Duel.IsExistingMatchingCard(c54977057.filter, tp, LOCATION_HAND, 0, 1, nil)
+    end
+    Duel.SetOperationInfo(0, CATEGORY_DRAW, nil, 0, tp, 2)
+    Duel.SetOperationInfo(0, CATEGORY_REMOVE, nil, 1, tp, LOCATION_HAND)
+end
+function c54977057.activate(e, tp, eg, ep, ev, re, r, rp)
+    Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_REMOVE)
+    local g = Duel.SelectMatchingCard(tp, c54977057.filter, tp, LOCATION_HAND, 0, 1, 1, nil)
+    Duel.Remove(g, POS_FACEUP, REASON_EFFECT)
+    Duel.Draw(tp, 2, REASON_EFFECT)
+end

--- a/706/c71490127.lua
+++ b/706/c71490127.lua
@@ -1,0 +1,98 @@
+-- 龍の鏡
+---@param c Card
+function c71490127.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_REMOVE + CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c71490127.target)
+    e1:SetOperation(c71490127.activate)
+    c:RegisterEffect(e1)
+end
+function c71490127.filter0(c)
+    return c:IsOnField() and c:IsAbleToRemove()
+end
+function c71490127.filter1(c, e)
+    return c:IsOnField() and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function c71490127.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsRace(RACE_DRAGON) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c71490127.filter3(c)
+    return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function c71490127.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp):Filter(c71490127.filter0, nil)
+        local mg2 = Duel.GetMatchingGroup(c71490127.filter3, tp, LOCATION_GRAVE, 0, nil)
+        mg1:Merge(mg2)
+        local res = Duel.IsExistingMatchingCard(c71490127.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg3 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c71490127.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg3, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+    Duel.SetOperationInfo(0, CATEGORY_REMOVE, nil, 1, tp, LOCATION_ONFIELD + LOCATION_GRAVE)
+end
+function c71490127.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c71490127.filter1, nil, e)
+    local mg2 = Duel.GetMatchingGroup(c71490127.filter3, tp, LOCATION_GRAVE, 0, nil)
+    mg1:Merge(mg2)
+    local sg1 = Duel.GetMatchingGroup(c71490127.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg3 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg3 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c71490127.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg3, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.Remove(mat1, POS_FACEUP, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg3, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2)
+        end
+        tc:CompleteProcedure()
+    else
+        if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_REMOVE) then
+            local cg1 = Duel.GetFieldGroup(tp, LOCATION_MZONE, 0)
+            local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+            local ct = cg1:GetCount()
+            ct = ct + Duel.GetMatchingGroupCount(Card.IsType, tp, LOCATION_GRAVE, 0, nil, TYPE_MONSTER)
+            if ct > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+                not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+                Duel.ConfirmCards(1 - tp, cg1)
+                Duel.ConfirmCards(1 - tp, cg2)
+                Duel.ShuffleHand(tp)
+            end
+        end
+    end
+end

--- a/706/c71490127.lua
+++ b/706/c71490127.lua
@@ -91,7 +91,6 @@ function c71490127.activate(e, tp, eg, ep, ev, re, r, rp)
                 not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
                 Duel.ConfirmCards(1 - tp, cg1)
                 Duel.ConfirmCards(1 - tp, cg2)
-                Duel.ShuffleHand(tp)
             end
         end
     end

--- a/706/c74117290.lua
+++ b/706/c74117290.lua
@@ -1,0 +1,44 @@
+-- 暗黒界の取引
+---@param c Card
+function c74117290.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_HANDES + CATEGORY_DRAW)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c74117290.target)
+    e1:SetOperation(c74117290.activate)
+    c:RegisterEffect(e1)
+end
+function c74117290.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return Duel.IsPlayerCanDraw(tp, 1) and Duel.IsPlayerCanDraw(1 - tp, 1)
+    end
+    Duel.SetOperationInfo(0, CATEGORY_HANDES, nil, 0, PLAYER_ALL, 1)
+    Duel.SetOperationInfo(0, CATEGORY_DRAW, nil, 0, PLAYER_ALL, 1)
+end
+function c74117290.activate(e, tp, eg, ep, ev, re, r, rp)
+    local h1 = Duel.Draw(tp, 1, REASON_EFFECT)
+    local h2 = Duel.Draw(1 - tp, 1, REASON_EFFECT)
+    if h1 > 0 or h2 > 0 then
+        Duel.BreakEffect()
+    end
+    local g1 = Group.CreateGroup()
+	local g2 = Group.CreateGroup()
+    if h1 > 0 then
+        Duel.ShuffleHand(tp)
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_DISCARD)
+        g1 = Duel.SelectMatchingCard(tp, Card.IsDiscardable, tp, LOCATION_HAND, 0, 1, 1, nil)
+    end
+    if h2 > 0 then
+        Duel.ShuffleHand(1 - tp)
+        Duel.Hint(HINT_SELECTMSG, 1 - tp, HINTMSG_DISCARD)
+        g2 = Duel.SelectMatchingCard(1 - tp, Card.IsDiscardable, 1 - tp, LOCATION_HAND, 0, 1, 1, nil)
+    end
+    if g1:GetCount() ~= 0 then
+        Duel.SendtoGrave(g1, REASON_EFFECT + REASON_DISCARD)
+    end
+    if g2:GetCount() ~= 0 then
+        Duel.SendtoGrave(g2, REASON_EFFECT + REASON_DISCARD)
+    end
+end

--- a/706/c94820406.lua
+++ b/706/c94820406.lua
@@ -1,0 +1,88 @@
+-- ダーク・フュージョン
+function c94820406.initial_effect(c)
+    -- Activate
+    local e1 = Effect.CreateEffect(c)
+    e1:SetCategory(CATEGORY_SPECIAL_SUMMON + CATEGORY_FUSION_SUMMON)
+    e1:SetType(EFFECT_TYPE_ACTIVATE)
+    e1:SetCode(EVENT_FREE_CHAIN)
+    e1:SetTarget(c94820406.target)
+    e1:SetOperation(c94820406.activate)
+    c:RegisterEffect(e1)
+end
+function c94820406.filter1(c, e)
+    return not c:IsImmuneToEffect(e)
+end
+function c94820406.filter2(c, e, tp, m, f, chkf)
+    return c:IsType(TYPE_FUSION) and c:IsRace(RACE_FIEND) and (not f or f(c)) and
+               c:IsCanBeSpecialSummoned(e, SUMMON_TYPE_FUSION, tp, false, false) and c:CheckFusionMaterial(m, nil, chkf)
+end
+function c94820406.target(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        local chkf = tp
+        local mg1 = Duel.GetFusionMaterial(tp)
+        local res = Duel.IsExistingMatchingCard(c94820406.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg1, nil, chkf)
+        if not res then
+            local ce = Duel.GetChainMaterial(tp)
+            if ce ~= nil then
+                local fgroup = ce:GetTarget()
+                local mg2 = fgroup(ce, e, tp)
+                local mf = ce:GetValue()
+                res =
+                    Duel.IsExistingMatchingCard(c94820406.filter2, tp, LOCATION_EXTRA, 0, 1, nil, e, tp, mg2, mf, chkf)
+            end
+        end
+        return res
+    end
+    Duel.SetOperationInfo(0, CATEGORY_SPECIAL_SUMMON, nil, 1, tp, LOCATION_EXTRA)
+end
+function c94820406.activate(e, tp, eg, ep, ev, re, r, rp)
+    local chkf = tp
+    local mg1 = Duel.GetFusionMaterial(tp):Filter(c94820406.filter1, nil, e)
+    local sg1 = Duel.GetMatchingGroup(c94820406.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg1, nil, chkf)
+    local mg2 = nil
+    local sg2 = nil
+    local ce = Duel.GetChainMaterial(tp)
+    if ce ~= nil then
+        local fgroup = ce:GetTarget()
+        mg2 = fgroup(ce, e, tp)
+        local mf = ce:GetValue()
+        sg2 = Duel.GetMatchingGroup(c94820406.filter2, tp, LOCATION_EXTRA, 0, nil, e, tp, mg2, mf, chkf)
+    end
+    if sg1:GetCount() > 0 or (sg2 ~= nil and sg2:GetCount() > 0) then
+        local sg = sg1:Clone()
+        if sg2 then
+            sg:Merge(sg2)
+        end
+        Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_SPSUMMON)
+        local tg = sg:Select(tp, 1, 1, nil)
+        local tc = tg:GetFirst()
+        if sg1:IsContains(tc) and
+            (sg2 == nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp, ce:GetDescription())) then
+            local mat1 = Duel.SelectFusionMaterial(tp, tc, mg1, nil, chkf)
+            tc:SetMaterial(mat1)
+            Duel.SendtoGrave(mat1, REASON_EFFECT + REASON_MATERIAL + REASON_FUSION)
+            Duel.BreakEffect()
+            Duel.SpecialSummon(tc, SUMMON_TYPE_FUSION, tp, tp, false, false, POS_FACEUP)
+        else
+            local mat2 = Duel.SelectFusionMaterial(tp, tc, mg2, nil, chkf)
+            local fop = ce:GetOperation()
+            fop(ce, e, tp, tc, mat2, SUMMON_TYPE_FUSION)
+        end
+        tc:CompleteProcedure()
+        local e1 = Effect.CreateEffect(e:GetHandler())
+        e1:SetType(EFFECT_TYPE_SINGLE)
+        e1:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+        e1:SetReset(RESET_EVENT + RESETS_STANDARD + RESET_PHASE + PHASE_END)
+        e1:SetValue(aux.tgoval)
+        tc:RegisterEffect(e1)
+    else
+        local cg1 = Duel.GetFieldGroup(tp, LOCATION_HAND + LOCATION_MZONE, 0)
+        local cg2 = Duel.GetFieldGroup(tp, LOCATION_EXTRA, 0)
+        if cg1:GetCount() > 1 and cg2:IsExists(Card.IsFacedown, 1, nil) and Duel.IsPlayerCanSpecialSummon(tp) and
+            not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_SPECIAL_SUMMON) then
+            Duel.ConfirmCards(1 - tp, cg1)
+            Duel.ConfirmCards(1 - tp, cg2)
+            Duel.ShuffleHand(tp)
+        end
+    end
+end

--- a/706/c94886282.lua
+++ b/706/c94886282.lua
@@ -1,0 +1,37 @@
+--光の援軍
+---@param c Card
+function c94886282.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c94886282.cost)
+	e1:SetTarget(c94886282.target)
+	e1:SetOperation(c94886282.activate)
+	c:RegisterEffect(e1)
+end
+function c94886282.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeckAsCost(tp,3) end
+	Duel.DiscardDeck(tp,3,REASON_COST)
+end
+function c94886282.filter(c)
+	return c:IsSetCard(0x38) and c:IsLevelBelow(4) and c:IsAbleToHand()
+end
+function c94886282.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c94886282.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c94886282.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c94886282.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	else 
+		if not Duel.IsPlayerAffectedByEffect(tp, EFFECT_CANNOT_TO_HAND) then
+			Duel.ConfirmCards(1-tp,Duel.GetFieldGroup(tp,0,LOCATION_DECK))
+			Duel.ShuffleDeck(tp)
+		end
+	end
+end


### PR DESCRIPTION
1、706服涉嫌融合的融合魔法卡效果处理时如果融不出来，根据公开情报无法确认的，融合方需要向对手展示手牌、里侧怪兽、额外卡组等相应区域
2、侦察者拉不出人需要展示卡组
3、荒行效果处理时如果对象怪兽攻击力是截止到11年8月31日的卡池中已有的六武众怪兽且卡组无人可拉就要展示卡组
4、天空的宝札、黑羽的宝札跟强欲而谦虚之壶同步自肃，不入连锁特招被警的回合不能开

注：由于科乐美11年的弱智裁定，奇迹融合可能还需要额外进行一段复杂判断以决定是否展示手牌。如果有必要我会去再改