### PR TITLE
Add global draw override utility and apply to Mulcharmys

### DIFF
--- a/4GX/README.md
+++ b/4GX/README.md
@@ -1,0 +1,13 @@
+# Overview
+
+This module changes the card-draw amount from 1 to X for a small, explicit allow-list of cards.
+
+## Affected cards (4):
+
+* 増殖するG
+* マルチャミー・フワロス
+* マルチャミー・プルリア
+* マルチャミー・ニャルス
+
+Any time one of the above cards would draw 1 card, it instead draws X cards.
+

--- a/4GX/c23434538.lua
+++ b/4GX/c23434538.lua
@@ -1,0 +1,71 @@
+--増殖するG
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCountLimit(1,id)
+	e1:SetCost(s.cost)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(s.drcon1)
+	e1:SetOperation(s.drop1)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	--sp_summon effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetCondition(s.regcon)
+	e2:SetOperation(s.regop)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetCode(EVENT_CHAIN_SOLVED)
+	e3:SetCondition(s.drcon2)
+	e3:SetOperation(s.drop2)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function s.filter(c,sp)
+	return c:IsSummonPlayer(sp)
+end
+function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and not Duel.IsChainSolving()
+end
+function s.drop1(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Draw(tp,1*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and Duel.IsChainSolving()
+end
+function s.regop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.RegisterFlagEffect(tp,id,RESET_CHAIN,0,1)
+end
+function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFlagEffect(tp,id)>0
+end
+function s.drop2(e,tp,eg,ep,ev,re,r,rp)
+	local n=Duel.GetFlagEffect(tp,id)
+	Duel.ResetFlagEffect(tp,id)
+	Duel.Draw(tp,n*DrawOverride.VALUE,REASON_EFFECT)
+end

--- a/4GX/c42141493.lua
+++ b/4GX/c42141493.lua
@@ -1,0 +1,111 @@
+--マルチャミー・フワロス
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(s.drcon)
+	e1:SetCost(s.drcost)
+	e1:SetOperation(s.drop)
+	c:RegisterEffect(e1)
+	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
+end
+function s.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+end
+function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+	local e3=Effect.CreateEffect(e:GetHandler())
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e3:SetTargetRange(1,0)
+	e3:SetCondition(s.actcon)
+	e3:SetValue(s.aclimit)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function s.chainfilter(re,tp,cid)
+	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
+end
+function s.actcon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
+end
+function s.aclimit(e,re,tp)
+	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
+end
+function s.drop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(s.drcon1)
+	e1:SetOperation(s.drop1)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetCondition(s.regcon)
+	e2:SetOperation(s.regop)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetCode(EVENT_CHAIN_SOLVED)
+	e3:SetCondition(s.drcon2)
+	e3:SetOperation(s.drop2)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+	local e4=Effect.CreateEffect(e:GetHandler())
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_PHASE+PHASE_END)
+	e4:SetCountLimit(1)
+	e4:SetCondition(s.tdcon)
+	e4:SetOperation(s.tdop)
+	e4:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e4,tp)
+end
+function s.filter(c,sp)
+	return c:IsSummonPlayer(sp) and c:IsSummonLocation(LOCATION_DECK+LOCATION_EXTRA)
+		and c:GetOriginalType()&TYPE_MONSTER~=0
+end
+function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and not Duel.IsChainSolving()
+end
+function s.drop1(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Draw(tp,1*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and Duel.IsChainSolving()
+end
+function s.regop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+end
+function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFlagEffect(tp,id+o)>0
+end
+function s.drop2(e,tp,eg,ep,ev,re,r,rp)
+	local n=Duel.GetFlagEffect(tp,id+o)
+	Duel.ResetFlagEffect(tp,id+o)
+	Duel.Draw(tp,n*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6
+end
+function s.tdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(e:GetOwnerPlayer(),LOCATION_HAND,0)
+	local d=Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)-(Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6)
+	local sg=g:RandomSelect(e:GetOwnerPlayer(),d)
+	Duel.SendtoDeck(sg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+end

--- a/4GX/c84192580.lua
+++ b/4GX/c84192580.lua
@@ -1,0 +1,116 @@
+--マルチャミー・プルリア
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(s.drcon)
+	e1:SetCost(s.drcost)
+	e1:SetOperation(s.drop)
+	c:RegisterEffect(e1)
+	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
+end
+function s.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+end
+function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+	local e3=Effect.CreateEffect(e:GetHandler())
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e3:SetTargetRange(1,0)
+	e3:SetCondition(s.actcon)
+	e3:SetValue(s.aclimit)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function s.chainfilter(re,tp,cid)
+	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
+end
+function s.actcon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
+end
+function s.aclimit(e,re,tp)
+	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
+end
+function s.drop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(s.drcon1)
+	e1:SetOperation(s.drop1)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCondition(s.regcon)
+	e3:SetOperation(s.regop)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+	local e4=e3:Clone()
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	Duel.RegisterEffect(e4,tp)
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e5:SetCode(EVENT_CHAIN_SOLVED)
+	e5:SetCondition(s.drcon2)
+	e5:SetOperation(s.drop2)
+	e5:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e5,tp)
+	local e6=Effect.CreateEffect(e:GetHandler())
+	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e6:SetCode(EVENT_PHASE+PHASE_END)
+	e6:SetCountLimit(1)
+	e6:SetCondition(s.tdcon)
+	e6:SetOperation(s.tdop)
+	e6:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e6,tp)
+end
+function s.filter(c,sp)
+	return c:IsSummonPlayer(sp) and c:IsSummonLocation(LOCATION_HAND)
+end
+function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and not Duel.IsChainSolving()
+end
+function s.drop1(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Draw(tp,1*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and Duel.IsChainSolving()
+end
+function s.regop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+end
+function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFlagEffect(tp,id+o)>0
+end
+function s.drop2(e,tp,eg,ep,ev,re,r,rp)
+	local n=Duel.GetFlagEffect(tp,id+o)
+	Duel.ResetFlagEffect(tp,id+o)
+	Duel.Draw(tp,n*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6
+end
+function s.tdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(e:GetOwnerPlayer(),LOCATION_HAND,0)
+	local d=Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)-(Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6)
+	local sg=g:RandomSelect(e:GetOwnerPlayer(),d)
+	Duel.SendtoDeck(sg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+end

--- a/4GX/c87126721.lua
+++ b/4GX/c87126721.lua
@@ -1,0 +1,111 @@
+--マルチャミー・ニャルス
+local s,id,o=GetID()
+function s.initial_effect(c)
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(s.drcon)
+	e1:SetCost(s.drcost)
+	e1:SetOperation(s.drop)
+	c:RegisterEffect(e1)
+	Duel.AddCustomActivityCounter(id,ACTIVITY_CHAIN,s.chainfilter)
+end
+function s.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==0 and Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)<2
+end
+function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsDiscardable() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST+REASON_DISCARD)
+	local e3=Effect.CreateEffect(e:GetHandler())
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e3:SetTargetRange(1,0)
+	e3:SetCondition(s.actcon)
+	e3:SetValue(s.aclimit)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function s.chainfilter(re,tp,cid)
+	return not (re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2))
+end
+function s.actcon(e)
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetCustomActivityCount(id,tp,ACTIVITY_CHAIN)>1
+end
+function s.aclimit(e,re,tp)
+	return re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x1b2)
+end
+function s.drop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(s.drcon1)
+	e1:SetOperation(s.drop1)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetCondition(s.regcon)
+	e2:SetOperation(s.regop)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetCode(EVENT_CHAIN_SOLVED)
+	e3:SetCondition(s.drcon2)
+	e3:SetOperation(s.drop2)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+	local e4=Effect.CreateEffect(e:GetHandler())
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_PHASE+PHASE_END)
+	e4:SetCountLimit(1)
+	e4:SetCondition(s.tdcon)
+	e4:SetOperation(s.tdop)
+	e4:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e4,tp)
+end
+function s.filter(c,sp)
+	return c:IsSummonPlayer(sp) and c:IsSummonLocation(LOCATION_GRAVE+LOCATION_REMOVED)
+		and c:GetOriginalType()&TYPE_MONSTER~=0
+end
+function s.drcon1(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and not Duel.IsChainSolving()
+end
+function s.drop1(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Draw(tp,1*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.filter,1,nil,1-tp)
+		and Duel.IsChainSolving()
+end
+function s.regop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.RegisterFlagEffect(tp,id+o,RESET_CHAIN,0,1)
+end
+function s.drcon2(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFlagEffect(tp,id+o)>0
+end
+function s.drop2(e,tp,eg,ep,ev,re,r,rp)
+	local n=Duel.GetFlagEffect(tp,id+o)
+	Duel.ResetFlagEffect(tp,id+o)
+	Duel.Draw(tp,n*DrawOverride.VALUE,REASON_EFFECT)
+end
+function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)>Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6
+end
+function s.tdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(e:GetOwnerPlayer(),LOCATION_HAND,0)
+	local d=Duel.GetFieldGroupCount(e:GetOwnerPlayer(),LOCATION_HAND,0)-(Duel.GetFieldGroupCount(e:GetOwnerPlayer(),0,LOCATION_ONFIELD)+6)
+	local sg=g:RandomSelect(e:GetOwnerPlayer(),d)
+	Duel.SendtoDeck(sg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+end

--- a/4GX/special.lua
+++ b/4GX/special.lua
@@ -1,0 +1,6 @@
+-- Change DrawOverride.VALUE to set the replacement for "draw 1".
+
+if not DrawOverride then DrawOverride = {} end
+
+-- CONFIG: set your global draw amount here
+DrawOverride.VALUE = DrawOverride.VALUE or 5  -- ← change this to any integer >=1


### PR DESCRIPTION
Base on user request.

This PR introduces a mode (4GX) that allows replacing all “draw 1” events for specific cards with a configurable number (default: 5).

```
Duel.Draw(tp,1,...) replaced with Duel.Draw(tp,1*DrawOverride.VALUE, ...).
Duel.Draw(tp,n,...) (for accumulated draws) replaced with Duel.Draw(tp,n*DrawOverride.VALUE, ...).
```