### PR TITLE
批量修改

### DIFF
--- a/706/c10032958.lua
+++ b/706/c10032958.lua
@@ -1,0 +1,89 @@
+--神竜－エクセリオン
+---@param c Card
+function c10032958.initial_effect(c)
+	--to defense
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(10032958,0))
+	e1:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetOperation(c10032958.effop)
+	c:RegisterEffect(e1)
+end
+function c10032958.effop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ct=Duel.GetMatchingGroupCount(Card.IsCode,tp,LOCATION_GRAVE,0,nil,10032958)
+	if ct>3 then ct=3 end
+	if ct>0 and c:IsFaceup() and c:IsRelateToEffect(e) then
+		local opt1=Duel.SelectOption(tp,aux.Stringid(10032958,1),aux.Stringid(10032958,2),aux.Stringid(10032958,3))
+		local opt2=0
+		local opt3=0
+		c10032958.reg(c,opt1)
+		if ct<2 then return end
+		if opt1==0 then opt2=Duel.SelectOption(tp,aux.Stringid(10032958,2),aux.Stringid(10032958,3))+1
+		elseif opt1==2 then opt2=Duel.SelectOption(tp,aux.Stringid(10032958,1),aux.Stringid(10032958,2))
+		else
+			opt2=Duel.SelectOption(tp,aux.Stringid(10032958,1),aux.Stringid(10032958,3))
+			if opt2==1 then opt2=2 end
+		end
+		c10032958.reg(c,opt2)
+		if ct<3 then return end
+		if opt1~=0 and opt2~=0 then opt3=Duel.SelectOption(tp,aux.Stringid(10032958,1))
+		elseif opt1~=1 and opt2~=1 then opt3=Duel.SelectOption(tp,aux.Stringid(10032958,2))+1
+		else opt3=Duel.SelectOption(tp,aux.Stringid(10032958,3))+2 end
+		c10032958.reg(c,opt3)
+	end
+end
+function c10032958.reg(c,opt)
+	if opt==0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	elseif opt==1 then
+		--chain attack
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(10032958,2))
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+		e1:SetCode(EVENT_BATTLE_DESTROYING)
+		e1:SetCondition(c10032958.atcon)
+		e1:SetOperation(c10032958.atop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	else
+		--damage
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(10032958,3))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_DAMAGE_STEP_END)
+		e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+		e1:SetCondition(aux.dserodcon)
+		e1:SetTarget(c10032958.damtg)
+		e1:SetOperation(c10032958.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	end
+end
+function c10032958.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.bdocon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+end
+function c10032958.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end
+function c10032958.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	local dam=bc:GetAttack()
+	if dam<0 then dam=0 end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c10032958.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c11012887.lua
+++ b/706/c11012887.lua
@@ -1,19 +1,16 @@
 --ジュラック・グアイバ
 function c11012887.initial_effect(c)
-	--special summon
+	-- special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(11012887,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_DAMAGE_STEP_END)
-	e1:SetCondition(c11012887.condition)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
 	e1:SetTarget(c11012887.target)
 	e1:SetOperation(c11012887.operation)
 	c:RegisterEffect(e1)
-end
-function c11012887.condition(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetBattleMonster(1-tp)
-	return tc:IsReason(REASON_BATTLE)
 end
 function c11012887.filter(c,e,tp)
 	return c:IsSetCard(0x22) and c:IsAttackBelow(1700) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/706/c12079734.lua
+++ b/706/c12079734.lua
@@ -1,0 +1,69 @@
+--デルタトライ
+---@param c Card
+function c12079734.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(12079734,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c12079734.target)
+	e1:SetOperation(c12079734.operation)
+	c:RegisterEffect(e1)
+end
+c12079734.has_text_type=TYPE_UNION
+function c12079734.filter1(c,ec)
+	return c:IsType(TYPE_UNION) and c:CheckUnionTarget(ec) and aux.CheckUnionEquip(c,ec)
+end
+function c12079734.filter2(c)
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToDeck()
+end
+function c12079734.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then
+		if e:GetLabel()==0 then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c12079734.filter1(chkc,c)
+		else return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c12079734.filter2(chkc) end
+	end
+	local b1=Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c12079734.filter1,tp,LOCATION_GRAVE,0,1,nil,c) and c:IsOnField()
+	local b2=Duel.IsExistingTarget(c12079734.filter2,tp,LOCATION_MZONE,0,1,nil) and Duel.IsPlayerCanDraw(tp,1)
+	if chk==0 then return true end
+	local op=-1
+	if b1 and b2 then
+		op=Duel.SelectOption(tp,aux.Stringid(12079734,1),aux.Stringid(12079734,2))
+	elseif b1 then
+		op=Duel.SelectOption(tp,aux.Stringid(12079734,1))
+	elseif b2 then op=Duel.SelectOption(tp,aux.Stringid(12079734,2))+1 end
+	e:SetLabel(op)
+	if op==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		local g=Duel.SelectTarget(tp,c12079734.filter1,tp,LOCATION_GRAVE,0,1,1,nil,c)
+		e:SetCategory(CATEGORY_EQUIP)
+		Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+		local g=Duel.SelectTarget(tp,c12079734.filter2,tp,LOCATION_MZONE,0,1,1,nil)
+		e:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)
+		Duel.SetOperationInfo(0,CATEGORY_TODECK,g,1,0,0)
+		Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+	end
+end
+function c12079734.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if e:GetLabel()==0 then
+		local c=e:GetHandler()
+		if c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e)
+			and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+			and aux.CheckUnionEquip(tc,c) and Duel.Equip(tp,tc,c,false) then
+			aux.SetUnionState(tc)
+		end
+	elseif e:GetLabel()==1 then
+		if tc:IsRelateToEffect(e) and Duel.SendtoDeck(tc,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_DECK+LOCATION_EXTRA) then
+			if tc:IsLocation(LOCATION_DECK) then Duel.ShuffleDeck(tp) end
+			Duel.BreakEffect()
+			Duel.Draw(tp,1,REASON_EFFECT)
+		end
+	end
+end

--- a/706/c12174035.lua
+++ b/706/c12174035.lua
@@ -1,0 +1,65 @@
+--ハイドロプレッシャーカノン
+---@param c Card
+function c12174035.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CONTINUOUS_TARGET)
+	e1:SetTarget(c12174035.target)
+	e1:SetOperation(c12174035.operation)
+	c:RegisterEffect(e1)
+	--Equip limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_EQUIP_LIMIT)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetValue(c12174035.eqlimit)
+	c:RegisterEffect(e2)
+	--handes
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(12174035,0))
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCategory(CATEGORY_TOGRAVE)
+	e3:SetCode(EVENT_BATTLE_DESTROYING)
+	e3:SetCondition(c12174035.hdcon)
+	e3:SetTarget(c12174035.hdtg)
+	e3:SetOperation(c12174035.hdop)
+	c:RegisterEffect(e3)
+end
+function c12174035.eqlimit(e,c)
+	return c:IsLevelBelow(3) and c:IsAttribute(ATTRIBUTE_WATER)
+end
+function c12174035.filter(c)
+	return c:IsFaceup() and c:IsLevelBelow(3) and c:IsAttribute(ATTRIBUTE_WATER)
+end
+function c12174035.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c12174035.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c12174035.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c12174035.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c12174035.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+	end
+end
+function c12174035.hdcon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return eg:GetFirst()==c:GetEquipTarget() and eg:GetFirst():IsStatus(STATUS_OPPO_BATTLE) and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c12174035.hdtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,1-tp,LOCATION_HAND)
+end
+function c12174035.hdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
+	if g:GetCount()==0 then return end
+	local sg=g:RandomSelect(tp,1)
+	Duel.SendtoGrave(sg,REASON_EFFECT)
+end

--- a/706/c14089428.lua
+++ b/706/c14089428.lua
@@ -1,0 +1,32 @@
+--ブルーサンダーT45
+---@param c Card
+function c14089428.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(14089428,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c14089428.target)
+	e1:SetOperation(c14089428.operation)
+	c:RegisterEffect(e1)
+end
+function c14089428.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
+end
+function c14089428.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+		or not Duel.IsPlayerCanSpecialSummonMonster(tp,14089429,0,TYPES_TOKEN_MONSTER,1500,1500,4,RACE_MACHINE,ATTRIBUTE_LIGHT) then return end
+	local token=Duel.CreateToken(tp,14089429)
+	Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UNRELEASABLE_SUM)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetValue(1)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+	token:RegisterEffect(e1)
+end

--- a/706/c14644902.lua
+++ b/706/c14644902.lua
@@ -1,0 +1,62 @@
+--幻想召喚師
+---@param c Card
+function c14644902.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(14644902,0))
+	e1:SetCategory(CATEGORY_RELEASE+CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP)
+	e1:SetTarget(c14644902.target)
+	e1:SetOperation(c14644902.operation)
+	c:RegisterEffect(e1)
+end
+function c14644902.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c14644902.rfilter(c,e,tp)
+	return not c:IsImmuneToEffect(e)
+		and Duel.IsExistingMatchingCard(c14644902.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c)
+end
+function c14644902.filter(c,e,tp,mc)
+	return c:IsType(TYPE_FUSION) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.GetLocationCountFromEx(tp,tp,mc,c)>0
+end
+function c14644902.rfilter2(c,tp)
+	return Duel.GetLocationCountFromEx(tp,tp,c,TYPE_FUSION)>0
+end
+function c14644902.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local rg=Duel.SelectReleaseGroupEx(tp,c14644902.rfilter,1,1,REASON_EFFECT,false,aux.ExceptThisCard(e),e,tp)
+	if #rg==0 then
+		rg=Duel.SelectReleaseGroupEx(tp,c14644902.rfilter2,1,1,REASON_EFFECT,false,aux.ExceptThisCard(e),tp)
+	end
+	if #rg>0 then
+		if Duel.Release(rg,REASON_EFFECT)>0 then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=Duel.SelectMatchingCard(tp,c14644902.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
+			if sg:GetCount()>0 then
+				Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+				local fid=c:GetFieldID()
+				sg:GetFirst():RegisterFlagEffect(14644902,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1,fid)
+				local e1=Effect.CreateEffect(c)
+				e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+				e1:SetCode(EVENT_PHASE+PHASE_END)
+				e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+				e1:SetLabel(fid)
+				e1:SetLabelObject(sg:GetFirst())
+				e1:SetCondition(c14644902.descon)
+				e1:SetOperation(c14644902.desop)
+				e1:SetReset(RESET_PHASE+PHASE_END)
+				e1:SetCountLimit(1)
+				Duel.RegisterEffect(e1,tp)
+			end
+		end
+	end
+end
+function c14644902.descon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	return tc:GetFlagEffectLabel(14644902)==e:GetLabel()
+end
+function c14644902.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetLabelObject(),REASON_EFFECT)
+end

--- a/706/c15013468.lua
+++ b/706/c15013468.lua
@@ -1,0 +1,76 @@
+--アンドロ・スフィンクス
+---@param c Card
+function c15013468.initial_effect(c)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c15013468.spcon)
+	e2:SetOperation(c15013468.spop)
+	c:RegisterEffect(e2)
+	--damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(15013468,0))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetCondition(c15013468.damcon)
+	e3:SetTarget(c15013468.damtg)
+	e3:SetOperation(c15013468.damop)
+	c:RegisterEffect(e3)
+	--cannot attack
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetOperation(c15013468.atklimit)
+	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e5)
+end
+function c15013468.atklimit(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_ATTACK)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+	e:GetHandler():RegisterEffect(e1)
+end
+function c15013468.cfilter(c)
+	return c:IsFaceup() and c:IsCode(53569894)
+end
+function c15013468.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and Duel.CheckLPCost(c:GetControler(),500)
+		and Duel.IsExistingMatchingCard(c15013468.cfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+end
+function c15013468.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	Duel.PayLPCost(tp,500)
+end
+function c15013468.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and bit.band(bc:GetBattlePosition(),POS_DEFENSE)~=0
+end
+function c15013468.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local dam=math.floor(e:GetHandler():GetBattleTarget():GetBaseAttack()/2)
+	if dam<0 then dam=0 end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c15013468.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c16909657.lua
+++ b/706/c16909657.lua
@@ -1,0 +1,43 @@
+--レプティレス・スキュラ
+---@param c Card
+function c16909657.initial_effect(c)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(16909657,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCondition(c16909657.spcon)
+	e2:SetTarget(c16909657.sptg)
+	e2:SetOperation(c16909657.spop)
+	c:RegisterEffect(e2)
+end
+function c16909657.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and bc:GetPreviousAttackOnField()==0
+end
+function c16909657.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=e:GetHandler():GetBattleTarget()
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and tc:IsLocation(LOCATION_GRAVE) and tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) end
+	tc:CreateEffectRelation(e)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)
+end
+function c16909657.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetBattleTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetValue(RESET_TURN_SET)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+		tc:RegisterEffect(e2)
+	end
+end

--- a/706/c17313545.lua
+++ b/706/c17313545.lua
@@ -1,0 +1,32 @@
+--ゴーレム
+---@param c Card
+function c17313545.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e1:SetTarget(c17313545.distg)
+	c:RegisterEffect(e1)
+	--chain attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(17313545,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c17313545.atcon)
+	e2:SetOperation(c17313545.atop)
+	c:RegisterEffect(e2)
+end
+function c17313545.distg(e,c)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsType(TYPE_EFFECT)
+end
+function c17313545.atcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and c:IsChainAttackable()
+		and c:GetBattleTarget():IsAttribute(ATTRIBUTE_LIGHT)
+end
+function c17313545.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c1945387.lua
+++ b/706/c1945387.lua
@@ -18,16 +18,13 @@ function c1945387.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e2:SetCode(EVENT_DAMAGE_STEP_END)
-	e2:SetCondition(c1945387.drcon)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
 	e2:SetTarget(c1945387.drtg)
 	e2:SetOperation(c1945387.drop)
 	c:RegisterEffect(e2)
 end
 c1945387.material_setcode=0x8
-function c1945387.drcon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetBattleMonster(1-tp)
-	return tc:IsReason(REASON_BATTLE)
-end
 function c1945387.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetTargetPlayer(tp)

--- a/706/c21350571.lua
+++ b/706/c21350571.lua
@@ -97,7 +97,8 @@ function c21350571.drfilter(c,rc)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
 end
 function c21350571.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(c21350571.drfilter,1,nil,e:GetHandler():GetEquipTarget())
+	local c = e:GetHandler()
+	return eg:IsExists(c21350571.drfilter,1,nil,e:GetHandler():GetEquipTarget()) and c:GetControler() == c:GetEquipTarget():GetControler()
 end
 function c21350571.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/706/c218704.lua
+++ b/706/c218704.lua
@@ -1,0 +1,57 @@
+--フェンリル
+---@param c Card
+function c218704.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c218704.spcon)
+	e1:SetTarget(c218704.sptg)
+	e1:SetOperation(c218704.spop)
+	c:RegisterEffect(e1)
+	--skip draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(218704,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetOperation(c218704.skipop)
+	c:RegisterEffect(e2)
+end
+function c218704.spfilter(c)
+	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsAbleToRemoveAsCost()
+end
+function c218704.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c218704.spfilter,tp,LOCATION_GRAVE,0,2,nil)
+end
+function c218704.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
+	local g=Duel.GetMatchingGroup(c218704.spfilter,tp,LOCATION_GRAVE,0,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local sg=g:CancelableSelect(tp,2,2,nil)
+	if sg then
+		sg:KeepAlive()
+		e:SetLabelObject(sg)
+		return true
+	else return false end
+end
+function c218704.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=e:GetLabelObject()
+	Duel.Remove(g,POS_FACEUP,REASON_SPSUMMON)
+	g:DeleteGroup()
+end
+function c218704.skipop(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(0,1)
+	e1:SetCode(EFFECT_SKIP_DP)
+	e1:SetReset(RESET_PHASE+PHASE_DRAW+RESET_OPPO_TURN)
+	Duel.RegisterEffect(e1,tp)
+end

--- a/706/c23118924.lua
+++ b/706/c23118924.lua
@@ -1,0 +1,50 @@
+--エレメント・デビル
+---@param c Card
+function c23118924.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_BATTLED)
+	e1:SetCondition(c23118924.discon)
+	e1:SetOperation(c23118924.disop)
+	c:RegisterEffect(e1)
+	--chain attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(23118924,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c23118924.atcon)
+	e2:SetOperation(c23118924.atop)
+	c:RegisterEffect(e2)
+end
+function c23118924.filter(c,att)
+	return c:IsFaceup() and c:IsAttribute(att)
+end
+function c23118924.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return bc and bc:IsStatus(STATUS_BATTLE_DESTROYED) and not c:IsStatus(STATUS_BATTLE_DESTROYED)
+		and Duel.IsExistingMatchingCard(c23118924.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,ATTRIBUTE_EARTH)
+end
+function c23118924.disop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x17a0000)
+	bc:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DISABLE_EFFECT)
+	e2:SetReset(RESET_EVENT+0x17a0000)
+	bc:RegisterEffect(e2)
+end
+function c23118924.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+		and Duel.IsExistingMatchingCard(c23118924.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,ATTRIBUTE_WIND)
+end
+function c23118924.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c26669055.lua
+++ b/706/c26669055.lua
@@ -1,0 +1,31 @@
+--静寂の聖者
+---@param c Card
+function c26669055.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(26669055,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetOperation(c26669055.operation)
+	c:RegisterEffect(e1)
+end
+function c26669055.operation(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetTargetRange(0,1)
+	e1:SetCondition(c26669055.accon)
+	e1:SetValue(c26669055.aclimit)
+	e1:SetLabel(Duel.GetTurnCount())
+	e1:SetReset(RESET_PHASE+PHASE_END,2)
+	Duel.RegisterEffect(e1,tp)
+end
+function c26669055.accon(e)
+	return e:GetLabel()~=Duel.GetTurnCount()
+end
+function c26669055.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL)
+end

--- a/706/c3019642.lua
+++ b/706/c3019642.lua
@@ -1,0 +1,83 @@
+--サイバー・ダーク・キール
+---@param c Card
+function c3019642.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(3019642,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c3019642.eqtg)
+	e1:SetOperation(c3019642.eqop)
+	c:RegisterEffect(e1)
+	--damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(3019642,1))
+	e2:SetCategory(CATEGORY_DAMAGE)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetTarget(c3019642.damtg)
+	e2:SetOperation(c3019642.damop)
+	c:RegisterEffect(e2)
+end
+function c3019642.filter(c)
+	return c:IsLevelBelow(3) and c:IsRace(RACE_DRAGON) and not c:IsForbidden()
+end
+function c3019642.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and (chkc:IsControler(tp) or Duel.IsPlayerAffectedByEffect(tp,64753988)) and c3019642.filter(chkc) end
+	if chk==0 then return true end
+	local loc=Duel.IsPlayerAffectedByEffect(tp,64753988) and LOCATION_GRAVE or 0
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c3019642.filter,tp,LOCATION_GRAVE,loc,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c3019642.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsRace(RACE_DRAGON) then
+		local atk=tc:GetTextAttack()
+		if atk<0 then atk=0 end
+		if not Duel.Equip(tp,tc,c,false) then return end
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetValue(c3019642.eqlimit)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_IGNORE_IMMUNE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_EQUIP)
+		e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e3:SetValue(c3019642.repval)
+		tc:RegisterEffect(e3)
+	end
+end
+function c3019642.eqlimit(e,c)
+	return e:GetOwner()==c
+end
+function c3019642.repval(e,re,r,rp)
+	return bit.band(r,REASON_BATTLE)~=0
+end
+function c3019642.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(300)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,300)
+end
+function c3019642.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c31768112.lua
+++ b/706/c31768112.lua
@@ -1,0 +1,103 @@
+--オイルメン
+---@param c Card
+function c31768112.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(31768112,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c31768112.eqtg)
+	e1:SetOperation(c31768112.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(31768112,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c31768112.sptg)
+	e2:SetOperation(c31768112.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(aux.IsUnionState)
+	e3:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e3)
+	--draw
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(31768112,2))
+	e4:SetCategory(CATEGORY_DRAW)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c31768112.drcon)
+	e4:SetTarget(c31768112.drtg)
+	e4:SetOperation(c31768112.drop)
+	c:RegisterEffect(e4)
+	--eqlimit
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_UNION_LIMIT)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e5:SetValue(c31768112.eqlimit)
+	c:RegisterEffect(e5)
+end
+c31768112.old_union=true
+function c31768112.eqlimit(e,c)
+	return c:IsRace(RACE_MACHINE)
+end
+function c31768112.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:GetUnionCount()==0
+end
+function c31768112.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c31768112.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(31768112)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c31768112.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c31768112.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(31768112,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c31768112.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c31768112.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c31768112.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(31768112)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(31768112,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c31768112.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c31768112.drcon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and c:GetEquipTarget()==eg:GetFirst() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c31768112.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c31768112.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/706/c32314730.lua
+++ b/706/c32314730.lua
@@ -1,0 +1,83 @@
+--コアキメイル・クルセイダー
+---@param c Card
+function c32314730.initial_effect(c)
+	aux.AddCodeList(c,36623431)
+	--cost
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c32314730.mtcon)
+	e1:SetOperation(c32314730.mtop)
+	c:RegisterEffect(e1)
+	--salvage
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(32314730,0))
+	e2:SetCategory(CATEGORY_TOHAND)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetTarget(c32314730.thtg)
+	e2:SetOperation(c32314730.thop)
+	c:RegisterEffect(e2)
+end
+function c32314730.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c32314730.cfilter1(c)
+	return c:IsCode(36623431) and c:IsAbleToGraveAsCost()
+end
+function c32314730.cfilter2(c)
+	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_BEASTWARRIOR) and not c:IsPublic()
+end
+function c32314730.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
+	local g1=Duel.GetMatchingGroup(c32314730.cfilter1,tp,LOCATION_HAND,0,nil)
+	local g2=Duel.GetMatchingGroup(c32314730.cfilter2,tp,LOCATION_HAND,0,nil)
+	local select=2
+	if g1:GetCount()>0 and g2:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,0),aux.Stringid(32314730,1),aux.Stringid(32314730,2))
+	elseif g1:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,0),aux.Stringid(32314730,2))
+		if select==1 then select=2 end
+	elseif g2:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,1),aux.Stringid(32314730,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(32314730,2))
+		select=2
+	end
+	if select==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=g1:Select(tp,1,1,nil)
+		Duel.SendtoGrave(g,REASON_COST)
+	elseif select==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
+		local g=g2:Select(tp,1,1,nil)
+		Duel.ConfirmCards(1-tp,g)
+		Duel.ShuffleHand(tp)
+	else
+		Duel.Destroy(c,REASON_COST)
+	end
+end
+function c32314730.filter(c)
+	return c:IsSetCard(0x1d) and c:IsAbleToHand()
+end
+function c32314730.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c32314730.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c32314730.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c32314730.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c32314730.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/706/c34568403.lua
+++ b/706/c34568403.lua
@@ -1,0 +1,67 @@
+--アルカナフォースⅦ－THE CHARIOT
+---@param c Card
+function c34568403.initial_effect(c)
+	--coin
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(34568403,0))
+	e1:SetCategory(CATEGORY_COIN)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(aux.ArcanaCoinTarget)
+	e1:SetOperation(c34568403.coinop)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e2)
+	local e3=e1:Clone()
+	e3:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
+	c:RegisterEffect(e3)
+	--coin effect
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(34568403,1))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_DAMAGE_STEP_END)
+	e4:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e4:SetCondition(c34568403.spcon)
+	e4:SetTarget(c34568403.sptg)
+	e4:SetOperation(c34568403.spop)
+	c:RegisterEffect(e4)
+end
+function c34568403.coinop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local res=0
+	local toss=false
+	if Duel.IsPlayerAffectedByEffect(tp,73206827) then
+		res=1-Duel.SelectOption(tp,60,61)
+	else
+		res=Duel.TossCoin(tp,1)
+		toss=true
+	end
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if toss then
+		c:RegisterFlagEffect(FLAG_ID_REVERSAL_OF_FATE,RESET_EVENT+RESETS_STANDARD,0,1)
+	end
+	c:RegisterFlagEffect(FLAG_ID_ARCANA_COIN,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,res,63-res)
+	if res==0 then
+		Duel.GetControl(c,1-tp)
+	end
+end
+function c34568403.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:GetFlagEffectLabel(FLAG_ID_ARCANA_COIN)==1 and aux.dserodcon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c34568403.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tc=e:GetHandler():GetBattleTarget()
+	if chk==0 then return tc:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and ((tc:IsLocation(LOCATION_GRAVE) or tc:IsLocation(LOCATION_REMOVED) and tc:IsFaceup()) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			or tc:IsLocation(LOCATION_EXTRA) and tc:IsFaceup() and Duel.GetLocationCountFromEx(tp,tp,nil,tc)>0) end
+	Duel.SetTargetCard(tc)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)
+end
+function c34568403.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetBattleTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/706/c35514096.lua
+++ b/706/c35514096.lua
@@ -1,0 +1,70 @@
+--ロードブリティッシュ
+---@param c Card
+function c35514096.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(35514096,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c35514096.target)
+	e1:SetOperation(c35514096.operation)
+	c:RegisterEffect(e1)
+end
+function c35514096.filter(c)
+	return c:IsFacedown()
+end
+function c35514096.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c35514096.filter(chkc) end
+	if chk==0 then return true end
+	local c=e:GetHandler()
+	local t1=c:IsChainAttackable()
+	local t2=Duel.IsExistingTarget(c35514096.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+	local t3=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,35514097,0,TYPES_TOKEN_MONSTER,1200,1200,4,RACE_MACHINE,ATTRIBUTE_LIGHT)
+	local op=0
+	if t1 or t2 or t3 then
+		local m={}
+		local n={}
+		local ct=1
+		if t1 then m[ct]=aux.Stringid(35514096,1) n[ct]=1 ct=ct+1 end
+		if t2 then m[ct]=aux.Stringid(35514096,2) n[ct]=2 ct=ct+1 end
+		if t3 then m[ct]=aux.Stringid(35514096,3) n[ct]=3 ct=ct+1 end
+		local sp=Duel.SelectOption(tp,table.unpack(m))
+		op=n[sp+1]
+	end
+	e:SetLabel(op)
+	if op==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		local g=Duel.SelectTarget(tp,c35514096.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		e:SetCategory(CATEGORY_DESTROY)
+	elseif op==3 then
+		e:SetProperty(0)
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+		Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
+	else
+		e:SetProperty(0)
+		e:SetCategory(0)
+	end
+end
+function c35514096.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if e:GetLabel()==2 then
+		local tc=Duel.GetFirstTarget()
+		if tc:IsRelateToEffect(e) then
+			Duel.Destroy(tc,REASON_EFFECT)
+		end
+	elseif e:GetLabel()==3 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0
+			or not Duel.IsPlayerCanSpecialSummonMonster(tp,35514097,0,TYPES_TOKEN_MONSTER,1200,1200,4,RACE_MACHINE,ATTRIBUTE_LIGHT) then return end
+		local token=Duel.CreateToken(tp,35514097)
+		Duel.SpecialSummon(token,0,tp,tp,false,false,POS_FACEUP)
+	elseif e:GetLabel()==1 then
+		if c:IsRelateToBattle() then
+			Duel.ChainAttack()
+		end
+	end
+end

--- a/706/c35638627.lua
+++ b/706/c35638627.lua
@@ -1,0 +1,48 @@
+--ワーム・ウォーロード
+---@param c Card
+function c35638627.initial_effect(c)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--Disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_BATTLED)
+	e2:SetOperation(c35638627.disop)
+	c:RegisterEffect(e2)
+	--chain attack
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(35638627,0))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetCondition(c35638627.atcon)
+	e3:SetOperation(c35638627.atop)
+	c:RegisterEffect(e3)
+end
+function c35638627.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttackTarget()
+	local c=e:GetHandler()
+	if c==tc then tc=Duel.GetAttacker() end
+	if tc and tc:IsType(TYPE_EFFECT) and tc:IsStatus(STATUS_BATTLE_DESTROYED) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x17a0000)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetReset(RESET_EVENT+0x17a0000)
+		tc:RegisterEffect(e2)
+	end
+end
+function c35638627.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+end
+function c35638627.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c37115575.lua
+++ b/706/c37115575.lua
@@ -1,0 +1,87 @@
+--Sin トゥルース・ドラゴン
+---@param c Card
+function c37115575.initial_effect(c)
+	c:EnableReviveLimit()
+	c:SetUniqueOnField(1,1,c37115575.uqfilter,LOCATION_MZONE)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(37115575,0))
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_DESTROYED)
+	e1:SetRange(LOCATION_HAND+LOCATION_GRAVE)
+	e1:SetCondition(c37115575.spcon)
+	e1:SetCost(c37115575.spcost)
+	e1:SetTarget(c37115575.sptg)
+	e1:SetOperation(c37115575.spop)
+	c:RegisterEffect(e1)
+	--selfdes
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e7:SetRange(LOCATION_MZONE)
+	e7:SetCode(EFFECT_SELF_DESTROY)
+	e7:SetCondition(c37115575.descon)
+	c:RegisterEffect(e7)
+	--spson
+	local e8=Effect.CreateEffect(c)
+	e8:SetType(EFFECT_TYPE_SINGLE)
+	e8:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e8:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e8:SetValue(aux.FALSE)
+	c:RegisterEffect(e8)
+	--destroy
+	local e9=Effect.CreateEffect(c)
+	e9:SetDescription(aux.Stringid(37115575,1))
+	e9:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e9:SetCategory(CATEGORY_DESTROY)
+	e9:SetCode(EVENT_DAMAGE_STEP_END)
+	e9:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e9:SetCondition(aux.dserodcon)
+	e9:SetTarget(c37115575.detg)
+	e9:SetOperation(c37115575.deop)
+	c:RegisterEffect(e9)
+end
+function c37115575.uqfilter(c)
+	if Duel.IsPlayerAffectedByEffect(c:GetControler(),75223115) then
+		return c:IsCode(37115575)
+	else
+		return c:IsSetCard(0x23)
+	end
+end
+function c37115575.cfilter(c,tp)
+	return c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+		and c:IsPreviousSetCard(0x23) and c:GetPreviousCodeOnField()~=37115575 and not c:IsReason(REASON_RULE)
+end
+function c37115575.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c37115575.cfilter,1,nil,tp)
+end
+function c37115575.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.PayLPCost(tp,math.floor(Duel.GetLP(tp)/2))
+end
+function c37115575.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,true) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c37115575.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,true,POS_FACEUP)~=0 then
+		c:CompleteProcedure()
+	end
+end
+function c37115575.descon(e)
+	return not Duel.IsExistingMatchingCard(Card.IsFaceup,0,LOCATION_FZONE,LOCATION_FZONE,1,nil)
+end
+function c37115575.detg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c37115575.deop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end

--- a/706/c39761138.lua
+++ b/706/c39761138.lua
@@ -1,0 +1,43 @@
+--ネオフレムベル・シャーマン
+---@param c Card
+function c39761138.initial_effect(c)
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(39761138,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(c39761138.rmcon)
+	e1:SetTarget(c39761138.rmtg)
+	e1:SetOperation(c39761138.rmop)
+	c:RegisterEffect(e1)
+end
+function c39761138.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp)
+		and Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,3,nil,0x2c)
+end
+function c39761138.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and chkc:IsAbleToRemove() end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
+	if Duel.IsExistingMatchingCard(Card.IsType,tp,0,LOCATION_GRAVE,1,nil,TYPE_SPELL) then e:SetLabel(0)
+	else
+		e:SetLabel(1)
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+	end
+end
+function c39761138.rmop(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,3,nil,0x2c) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+		if e:GetLabel()==1 then
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,500,REASON_EFFECT)
+		end
+	end
+end

--- a/706/c41098335.lua
+++ b/706/c41098335.lua
@@ -1,0 +1,38 @@
+--ファイターズ・エイプ
+---@param c Card
+function c41098335.initial_effect(c)
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(41098335,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetOperation(c41098335.atkop)
+	c:RegisterEffect(e1)
+	--atk clear
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_TURN_END)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetOperation(c41098335.retop)
+	c:RegisterEffect(e2)
+end
+function c41098335.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(300)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	end
+end
+function c41098335.retop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetTurnPlayer()==tp and c:GetAttackedCount()==0 then
+		c:ResetEffect(RESET_DISABLE,RESET_EVENT)
+	end
+end

--- a/706/c41160533.lua
+++ b/706/c41160533.lua
@@ -1,0 +1,55 @@
+--ローズ・テンタクルス
+---@param c Card
+function c41160533.initial_effect(c)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_PHASE_START+PHASE_BATTLE_START)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c41160533.maop)
+	c:RegisterEffect(e2)
+	--special summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(41160533,0))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCondition(c41160533.damcon)
+	e3:SetTarget(c41160533.damtg)
+	e3:SetOperation(c41160533.damop)
+	c:RegisterEffect(e3)
+end
+function c41160533.mfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_PLANT)
+end
+function c41160533.maop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetTurnPlayer()~=tp then return end
+	local ct=Duel.GetMatchingGroupCount(c41160533.mfilter,tp,0,LOCATION_MZONE,nil)
+	if ct~=0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetValue(ct)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE+RESET_PHASE+PHASE_BATTLE)
+		e:GetHandler():RegisterEffect(e1)
+	end
+end
+function c41160533.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():GetBattleTarget():IsRace(RACE_PLANT)
+end
+function c41160533.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(300)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,300)
+end
+function c41160533.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c43405287.lua
+++ b/706/c43405287.lua
@@ -96,8 +96,9 @@ function c43405287.damfilter(c,rc)
 	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
 end
 function c43405287.damcon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetHandler():GetEquipTarget()
-	return tc and eg:IsExists(c43405287.damfilter,1,nil,tc)
+	local c = e:GetHandler()
+	local tc=c:GetEquipTarget()
+	return tc and eg:IsExists(c43405287.damfilter,1,nil,tc) and c:GetControler() == tc:GetControler()
 end
 function c43405287.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/706/c44178886.lua
+++ b/706/c44178886.lua
@@ -1,126 +1,151 @@
---ライトロード・モンク エイリン
+-- ライトロード・モンク エイリン
 function c44178886.initial_effect(c)
-	--to deck
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(44178886,0))
-	e1:SetCategory(CATEGORY_TODECK)
-	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
-	e1:SetCode(EVENT_BATTLE_CONFIRM)
-	e1:SetTarget(c44178886.targ)
-	e1:SetOperation(c44178886.op)
-	c:RegisterEffect(e1)
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
-	e2:SetCategory(CATEGORY_DECKDES)
-	e2:SetDescription(aux.Stringid(44178886,1))
-	e2:SetCode(EVENT_PHASE+PHASE_END)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetCountLimit(1000)
-	e2:SetCondition(c44178886.discon)
-	e2:SetTarget(c44178886.distg)
-	e2:SetOperation(c44178886.disop)
-	c:RegisterEffect(e2)
-	--监听堆墓效果被发动无效时去掉已发动标记
-	local e3=Effect.CreateEffect(c)
-    e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS) -- 设置为连续效果
+    -- to deck
+    local e1 = Effect.CreateEffect(c)
+    e1:SetDescription(aux.Stringid(44178886, 0))
+    e1:SetCategory(CATEGORY_TODECK)
+    e1:SetType(EFFECT_TYPE_SINGLE + EFFECT_TYPE_TRIGGER_F)
+    e1:SetCode(EVENT_BATTLE_CONFIRM)
+    e1:SetTarget(c44178886.targ)
+    e1:SetOperation(c44178886.op)
+    c:RegisterEffect(e1)
+    local e2 = Effect.CreateEffect(c)
+    e2:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_TRIGGER_F)
+    e2:SetCategory(CATEGORY_DECKDES)
+    e2:SetDescription(aux.Stringid(44178886, 1))
+    e2:SetCode(EVENT_PHASE + PHASE_END)
+    e2:SetRange(LOCATION_MZONE)
+    e2:SetCountLimit(1000)
+    e2:SetCondition(c44178886.discon)
+    e2:SetTarget(c44178886.distg)
+    e2:SetOperation(c44178886.disop)
+    c:RegisterEffect(e2)
+    -- 监听堆墓效果被发动无效时去掉已发动标记
+    local e3 = Effect.CreateEffect(c)
+    e3:SetType(EFFECT_TYPE_FIELD + EFFECT_TYPE_CONTINUOUS) -- 设置为连续效果
     e3:SetCode(EVENT_CHAIN_NEGATED) -- 特殊监听链被无效事件
     e3:SetRange(LOCATION_MZONE) -- 此效果以字段上存在为范围
     e3:SetOperation(c44178886.disflagcheck) -- 触发时，调用 negated_check 函数
-	e3:SetLabelObject(e2)
+    e3:SetLabelObject(e2)
     c:RegisterEffect(e3)
 end
-function c44178886.targ(e,tp,eg,ep,ev,re,r,rp,chk)
-	local t=Duel.GetAttackTarget()
-	if chk==0 then return Duel.GetAttacker()==e:GetHandler() and t~=nil and not t:IsAttackPos() and t:IsAbleToDeck() end
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,t,1,0,0)
+function c44178886.targ(e, tp, eg, ep, ev, re, r, rp, chk)
+    local t = Duel.GetAttackTarget()
+    if chk == 0 then
+        return Duel.GetAttacker() == e:GetHandler() and t ~= nil and not t:IsAttackPos() and t:IsAbleToDeck()
+    end
+    Duel.SetOperationInfo(0, CATEGORY_TODECK, t, 1, 0, 0)
 end
 
-
---限制：不能发动“反转效果（Flip）”
-function c44178886.aclimit(e,re,tp)
-    --re:GetHandler() 是正在尝试发动效果的卡
-    --反转效果的类型包含 EFFECT_TYPE_FLIP
-    return re:IsActiveType(TYPE_MONSTER) and re:GetCode()==EVENT_FLIP
+-- 限制：不能发动“反转效果（Flip）”
+function c44178886.aclimit(e, re, tp)
+    -- re:GetHandler() 是正在尝试发动效果的卡
+    -- 反转效果的类型包含 EFFECT_TYPE_FLIP
+    return re:IsActiveType(TYPE_MONSTER) and re:GetCode() == EVENT_FLIP
 end
-function c44178886.op(e,tp,eg,ep,ev,re,r,rp)
-    local c=e:GetHandler()
-    local t=Duel.GetAttackTarget()
-    if not (Duel.GetAttacker()==c and t~=nil and t:IsRelateToBattle() and not t:IsAttackPos() and t:IsAbleToDeck()) then return end
+function c44178886.op(e, tp, eg, ep, ev, re, r, rp)
+    local c = e:GetHandler()
+    local t = Duel.GetAttackTarget()
+    if not (Duel.GetAttacker() == c and t ~= nil and t:IsRelateToBattle() and not t:IsAttackPos() and t:IsAbleToDeck()) then
+        return
+    end
 
-	--仅对守墓侦察者这个特例临时增加一个对方玩家不能在伤害计算前发反转效果的永续效果以还原旧裁定
-	if t:GetCode()==24317029 then -- 替换为守墓侦察者的实际卡片代码
-		local e1=Effect.CreateEffect(c)
-		e1:SetType(EFFECT_TYPE_FIELD)
-		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e1:SetCode(EFFECT_CANNOT_ACTIVATE)
-		e1:SetTargetRange(0,1) --只影响对方玩家
-		e1:SetValue(c44178886.aclimit)
-		e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
-		Duel.RegisterEffect(e1,tp)
-	end
+    -- 仅对守墓侦察者这个特例临时增加一个对方玩家不能在伤害计算前发反转效果的永续效果以还原旧裁定
+    if t:GetCode() == 24317029 then -- 替换为守墓侦察者的实际卡片代码
+        local e1 = Effect.CreateEffect(c)
+        e1:SetType(EFFECT_TYPE_FIELD)
+        e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+        e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+        e1:SetTargetRange(0, 1) -- 只影响对方玩家
+        e1:SetValue(c44178886.aclimit)
+        e1:SetReset(RESET_PHASE + PHASE_DAMAGE)
+        Duel.RegisterEffect(e1, tp)
+    end
 
+    c44178886.attach_temp_todeck_flip(e, tp, t)
 
-    c44178886.attach_temp_todeck_flip(e,tp,t)
-
-    Duel.SendtoDeck(t,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+    Duel.SendtoDeck(t, nil, SEQ_DECKSHUFFLE, REASON_EFFECT)
 end
-function c44178886.attach_temp_todeck_flip(e,tp,t)
-    if not (t and t.GetFlipEffect) then return end
-    local fe=t:GetFlipEffect()
-    if not fe then return end
+function c44178886.attach_temp_todeck_flip(e, tp, t)
+    if not (t and t.GetFlipEffect) then
+        return
+    end
+    local fe = t:GetFlipEffect()
+    if not fe then
+        return
+    end
 
-    local te=fe:Clone()
+    local te = fe:Clone()
     te:SetCode(EVENT_TO_DECK)
 
-	if t:GetFlagEffect(44178886)~=0 then
+    if t:GetFlagEffect(44178886) ~= 0 then
         return nil
     end
-	t:RegisterFlagEffect(44178886,RESET_EVENT+RESET_CODE,0,1)
+    t:RegisterFlagEffect(44178886, RESET_EVENT + RESET_CODE, 0, 1)
+    if t:IsHasEffect(EFFECT_DISABLE_EFFECT) ~= nil then
+        t:RegisterFlagEffect(44178886, RESET_PHASE + PHASE_DAMAGE_CAL, 0, 1)
+    end
 
     -- 限制：只让“被武僧效果送回卡组”这一次触发
     local oldcon = te.GetCondition and te:GetCondition() or nil
-    te:SetCondition(function(e2,tp2,eg,ep,ev,re,r,rp)
-        if re~=e then return false end
-        if bit.band(r,REASON_EFFECT)==0 then return false end
+    te:SetCondition(function(e2, tp2, eg, ep, ev, re, r, rp)
+        if re ~= e then
+            return false
+        end
+        if bit.band(r, REASON_EFFECT) == 0 then
+            return false
+        end
         -- 保留原本 flip 的条件（如果有）
-        if oldcon then return oldcon(e2,tp2,eg,ep,ev,re,r,rp) end
+        if oldcon then
+            return oldcon(e2, tp2, eg, ep, ev, re, r, rp)
+        end
         return true
     end)
-	local oldop = te.GetOperation and te:GetOperation() or nil
-	te:SetOperation(function(e2,tp2,eg2,ep2,ev2,re2,r2,rp2)
-		if oldop then 
-			local wrap_reset_op = function(e2,tp2,eg2,ep2,ev2,re2,r2,rp2)
-				local op_result = oldop(e2,tp2,eg2,ep2,ev2,re2,r2,rp2) or nil
-				te:Reset()  -- 无论如何 reset 掉这个临时 effect，避免它一直挂在卡组里
-				t:ResetFlagEffect(44178886)  -- 重置标记，允许未来再次被武僧效果送回卡组时触发
-				return op_result
-			end
-			wrap_reset_op(e2,tp2,eg2,ep2,ev2,re2,r2,rp2) 
-		end
-	end)
+    local oldop = te.GetOperation and te:GetOperation() or nil
+    te:SetOperation(function(e2, tp2, eg2, ep2, ev2, re2, r2, rp2)
+        if oldop then
+            local wrap_reset_op = function(e2, tp2, eg2, ep2, ev2, re2, r2, rp2)
+                if t:GetFlagEffect(44178886) > 1 then
+                    te:Reset() -- 无论如何 reset 掉这个临时 effect，避免它一直挂在卡组里
+                    t:ResetFlagEffect(44178886) -- 重置标记，允许未来再次被武僧效果送回卡组时触发
+                    Duel.NegateEffect(0)
+                    return
+                else
+                    local op_result = oldop(e2, tp2, eg2, ep2, ev2, re2, r2, rp2) or nil
+                    te:Reset() -- 无论如何 reset 掉这个临时 effect，避免它一直挂在卡组里
+                    t:ResetFlagEffect(44178886) -- 重置标记，允许未来再次被武僧效果送回卡组时触发
+                    return op_result
+                end
 
-	t:RegisterEffect(te)
+            end
+            wrap_reset_op(e2, tp2, eg2, ep2, ev2, re2, r2, rp2)
+        end
+    end)
+
+    t:RegisterEffect(te)
 end
 
-function c44178886.discon(e,tp,eg,ep,ev,re,r,rp)
-	local c = e:GetHandler()
-	local fid = c:GetFieldID()
-	return tp==Duel.GetTurnPlayer() and c:GetFlagEffect(fid)==0
+function c44178886.discon(e, tp, eg, ep, ev, re, r, rp)
+    local c = e:GetHandler()
+    local fid = c:GetFieldID()
+    return tp == Duel.GetTurnPlayer() and c:GetFlagEffect(fid) == 0
 end
-function c44178886.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,tp,3)
-	local c = e:GetHandler()
-	local fid = c:GetFieldID()
-	c:RegisterFlagEffect(fid,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
+function c44178886.distg(e, tp, eg, ep, ev, re, r, rp, chk)
+    if chk == 0 then
+        return true
+    end
+    Duel.SetOperationInfo(0, CATEGORY_DECKDES, nil, 0, tp, 3)
+    local c = e:GetHandler()
+    local fid = c:GetFieldID()
+    c:RegisterFlagEffect(fid, RESET_EVENT + RESETS_STANDARD + RESET_PHASE + PHASE_END, 0, 1)
 end
-function c44178886.disop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.DiscardDeck(tp,3,REASON_EFFECT)
+function c44178886.disop(e, tp, eg, ep, ev, re, r, rp)
+    Duel.DiscardDeck(tp, 3, REASON_EFFECT)
 end
-function c44178886.disflagcheck(e,tp,eg,ep,ev,re,r,rp)
-	local c = e:GetHandler()
-	local fid = c:GetFieldID()
-	if e:GetLabelObject():GetFieldID() == re:GetFieldID() then
-		c:ResetFlagEffect(fid)
-	end
+function c44178886.disflagcheck(e, tp, eg, ep, ev, re, r, rp)
+    local c = e:GetHandler()
+    local fid = c:GetFieldID()
+    if e:GetLabelObject():GetFieldID() == re:GetFieldID() then
+        c:ResetFlagEffect(fid)
+    end
 end

--- a/706/c44178886.lua
+++ b/706/c44178886.lua
@@ -71,7 +71,7 @@ function c44178886.attach_temp_todeck_flip(e, tp, t)
         return
     end
     local fe = t:GetFlipEffect()
-    if not fe then
+    if not fe or bit.band(t:GetBattlePosition(),POS_FACEUP)~=0 then
         return
     end
 

--- a/706/c44913552.lua
+++ b/706/c44913552.lua
@@ -1,0 +1,23 @@
+--タイム・イーター
+---@param c Card
+function c44913552.initial_effect(c)
+	--skip draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44913552,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c44913552.skipop)
+	c:RegisterEffect(e2)
+end
+function c44913552.skipop(e,tp,eg,ep,ev,re,r,rp)
+	local e2=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(0,1)
+	e1:SetCode(EFFECT_SKIP_M1)
+	e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+	Duel.RegisterEffect(e1,tp)
+end

--- a/706/c46263076.lua
+++ b/706/c46263076.lua
@@ -1,0 +1,53 @@
+--地縛神 Ccapac Apu
+---@param c Card
+function c46263076.initial_effect(c)
+	c:SetUniqueOnField(1,1,aux.FilterBoolFunction(Card.IsSetCard,0x1021),LOCATION_MZONE)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(EFFECT_SELF_DESTROY)
+	e4:SetCondition(c46263076.sdcon)
+	c:RegisterEffect(e4)
+	--battle target
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e5:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetValue(aux.imval1)
+	c:RegisterEffect(e5)
+	--direct atk
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetCode(EFFECT_DIRECT_ATTACK)
+	c:RegisterEffect(e6)
+	--damage
+	local e7=Effect.CreateEffect(c)
+	e7:SetDescription(aux.Stringid(46263076,0))
+	e7:SetCategory(CATEGORY_DAMAGE)
+	e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e7:SetCode(EVENT_DAMAGE_STEP_END)
+	e7:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e7:SetCondition(aux.dserodcon)
+	e7:SetTarget(c46263076.damtg)
+	e7:SetOperation(c46263076.damop)
+	c:RegisterEffect(e7)
+end
+function c46263076.sdcon(e)
+	return not Duel.IsExistingMatchingCard(Card.IsFaceup,0,LOCATION_FZONE,LOCATION_FZONE,1,nil)
+end
+function c46263076.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local tc=e:GetHandler():GetBattleTarget()
+	local atk=tc:GetBaseAttack()
+	if atk<0 then atk=0 end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(atk)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk)
+end
+function c46263076.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c47228077.lua
+++ b/706/c47228077.lua
@@ -1,0 +1,106 @@
+--ヴァイロン・ペンタクロ
+---@param c Card
+function c47228077.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(47228077,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c47228077.eqtg)
+	e1:SetOperation(c47228077.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(47228077,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c47228077.sptg)
+	e2:SetOperation(c47228077.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(aux.IsUnionState)
+	e3:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e3)
+	--destroy
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(47228077,2))
+	e4:SetCategory(CATEGORY_DESTROY)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c47228077.descon)
+	e4:SetTarget(c47228077.destg)
+	e4:SetOperation(c47228077.desop)
+	c:RegisterEffect(e4)
+	--eqlimit
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_UNION_LIMIT)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e5:SetValue(c47228077.eqlimit)
+	c:RegisterEffect(e5)
+end
+c47228077.old_union=true
+function c47228077.eqlimit(e,c)
+	return c:IsSetCard(0x30)
+end
+function c47228077.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x30) and c:GetUnionCount()==0
+end
+function c47228077.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c47228077.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(47228077)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c47228077.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c47228077.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(47228077,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c47228077.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c47228077.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c47228077.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(47228077)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(47228077,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c47228077.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c47228077.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and c:GetEquipTarget()==eg:GetFirst() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c47228077.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c47228077.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/706/c47274077.lua
+++ b/706/c47274077.lua
@@ -1,0 +1,96 @@
+--ネオス・フォース
+---@param c Card
+function c47274077.initial_effect(c)
+	aux.AddCodeList(c,89943723)
+	aux.AddSetNameMonsterList(c,0x3008)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CONTINUOUS_TARGET)
+	e1:SetTarget(c47274077.target)
+	e1:SetOperation(c47274077.operation)
+	c:RegisterEffect(e1)
+	--atk
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(800)
+	c:RegisterEffect(e2)
+	--Equip limit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_EQUIP_LIMIT)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e3:SetValue(c47274077.eqlimit)
+	c:RegisterEffect(e3)
+	--damage
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(47274077,0))
+	e4:SetCategory(CATEGORY_DAMAGE)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetCondition(c47274077.damcon)
+	e4:SetTarget(c47274077.damtg)
+	e4:SetOperation(c47274077.damop)
+	c:RegisterEffect(e4)
+	--return
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(47274077,1))
+	e5:SetCategory(CATEGORY_TODECK)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e5:SetCode(EVENT_PHASE+PHASE_END)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCountLimit(1)
+	e5:SetTarget(c47274077.rettg)
+	e5:SetOperation(c47274077.retop)
+	c:RegisterEffect(e5)
+end
+function c47274077.eqlimit(e,c)
+	return c:IsCode(89943723)
+end
+function c47274077.filter(c)
+	return c:IsFaceup() and c:IsCode(89943723)
+end
+function c47274077.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c47274077.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c47274077.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c47274077.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c47274077.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,e:GetHandler(),tc)
+	end
+end
+function c47274077.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=eg:GetFirst()
+	local bc=ec:GetBattleTarget()
+	local c = e:GetHandler()
+	return ec==c:GetEquipTarget() and bc:IsLocation(LOCATION_GRAVE) and bc:IsReason(REASON_BATTLE) and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c47274077.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local ec=eg:GetFirst()
+	local bc=ec:GetBattleTarget()
+	local dam=bc:GetAttack()
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c47274077.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end
+function c47274077.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
+end
+function c47274077.retop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SendtoDeck(e:GetHandler(),nil,SEQ_DECKSHUFFLE,REASON_EFFECT)
+end

--- a/706/c48447192.lua
+++ b/706/c48447192.lua
@@ -1,0 +1,95 @@
+--剣の煌き
+---@param c Card
+function c48447192.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CONTINUOUS_TARGET)
+	e1:SetTarget(c48447192.target)
+	e1:SetOperation(c48447192.operation)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetDescription(aux.Stringid(48447192,0))
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_BATTLE_DESTROYING)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c48447192.descon)
+	e2:SetTarget(c48447192.destg)
+	e2:SetOperation(c48447192.desop)
+	c:RegisterEffect(e2)
+	--Equip limit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_EQUIP_LIMIT)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e3:SetValue(c48447192.eqlimit)
+	c:RegisterEffect(e3)
+	--todeck
+	local e4=Effect.CreateEffect(c)
+	e4:SetCategory(CATEGORY_TODECK)
+	e4:SetDescription(aux.Stringid(48447192,1))
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetRange(LOCATION_GRAVE)
+	e4:SetCost(c48447192.retcost)
+	e4:SetTarget(c48447192.rettg)
+	e4:SetOperation(c48447192.retop)
+	c:RegisterEffect(e4)
+end
+function c48447192.eqlimit(e,c)
+	return c:IsSetCard(0x100d)
+end
+function c48447192.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x100d)
+end
+function c48447192.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c48447192.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c48447192.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c48447192.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c48447192.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+	end
+end
+function c48447192.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	local ec=c:GetEquipTarget()
+	return ec and eg:IsContains(ec) and c:GetControler() == ec:GetControler()
+end
+function c48447192.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c48447192.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c48447192.retcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckReleaseGroup(tp,aux.TRUE,1,nil) end
+	local g=Duel.SelectReleaseGroup(tp,aux.TRUE,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c48447192.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToDeck() end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
+end
+function c48447192.retop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SendtoDeck(c,nil,SEQ_DECKTOP,REASON_EFFECT)
+	end
+end

--- a/706/c48568432.lua
+++ b/706/c48568432.lua
@@ -1,0 +1,110 @@
+--トライゴン
+---@param c Card
+function c48568432.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(48568432,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c48568432.eqtg)
+	e1:SetOperation(c48568432.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(48568432,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c48568432.sptg)
+	e2:SetOperation(c48568432.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(aux.IsUnionState)
+	e3:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e3)
+	--eqlimit
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_UNION_LIMIT)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetValue(c48568432.eqlimit)
+	c:RegisterEffect(e4)
+	--spsummon
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(48568432,2))
+	e5:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e5:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_FIELD)
+	e5:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCode(EVENT_BATTLE_DESTROYING)
+	e5:SetCondition(c48568432.spcon2)
+	e5:SetTarget(c48568432.sptg2)
+	e5:SetOperation(c48568432.spop2)
+	c:RegisterEffect(e5)
+end
+c48568432.old_union=true
+function c48568432.eqlimit(e,c)
+	return c:IsRace(RACE_MACHINE)
+end
+function c48568432.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_MACHINE) and c:GetUnionCount()==0
+end
+function c48568432.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c48568432.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(48568432)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c48568432.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c48568432.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(48568432,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c48568432.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c48568432.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c48568432.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(48568432)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(48568432,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c48568432.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c48568432.spcon2(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and eg:GetFirst()==c:GetEquipTarget() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c48568432.spfilter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c48568432.sptg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c48568432.spfilter(chkc,e,tp) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c48568432.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c48568432.spop2(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/706/c50933533.lua
+++ b/706/c50933533.lua
@@ -1,0 +1,108 @@
+--古代の機械巨竜
+---@param c Card
+function c50933533.initial_effect(c)
+	aux.AddCodeList(c,41172955,86445415,13839120)
+	--mat check
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_MATERIAL_CHECK)
+	e1:SetValue(c50933533.valcheck)
+	c:RegisterEffect(e1)
+	--summon success
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetCondition(c50933533.regcon)
+	e2:SetOperation(c50933533.regop)
+	c:RegisterEffect(e2)
+	e2:SetLabelObject(e1)
+	--actlimit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(0,1)
+	e3:SetValue(c50933533.aclimit)
+	e3:SetCondition(c50933533.actcon)
+	c:RegisterEffect(e3)
+end
+function c50933533.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c50933533.actcon(e)
+	return Duel.GetAttacker()==e:GetHandler()
+end
+function c50933533.valcheck(e,c)
+	local g=c:GetMaterial()
+	local flag=0
+	local tc=g:GetFirst()
+	while tc do
+		local code=tc:GetCode()
+		if code==41172955 then flag=bit.bor(flag,0x1)
+		elseif code==86445415 then flag=bit.bor(flag,0x2)
+		elseif code==13839120 then flag=bit.bor(flag,0x4)
+		end
+		tc=g:GetNext()
+	end
+	e:SetLabel(flag)
+end
+function c50933533.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_ADVANCE)
+end
+function c50933533.regop(e,tp,eg,ep,ev,re,r,rp)
+	local flag=e:GetLabelObject():GetLabel()
+	local c=e:GetHandler()
+	if bit.band(flag,0x1)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_PIERCE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+	if bit.band(flag,0x2)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(50933533,0))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DAMAGE)
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCondition(c50933533.damcon1)
+		e1:SetTarget(c50933533.damtg1)
+		e1:SetOperation(c50933533.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+	if bit.band(flag,0x4)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(50933533,1))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DESTROYING)
+		e1:SetTarget(c50933533.damtg2)
+		e1:SetOperation(c50933533.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+end
+function c50933533.damcon1(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp
+end
+function c50933533.damtg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(400)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,400)
+end
+function c50933533.damtg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(600)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,600)
+end
+function c50933533.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c51402177.lua
+++ b/706/c51402177.lua
@@ -1,0 +1,76 @@
+--スフィンクス・テーレイア
+---@param c Card
+function c51402177.initial_effect(c)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c51402177.spcon)
+	e2:SetOperation(c51402177.spop)
+	c:RegisterEffect(e2)
+	--damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(51402177,0))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetCondition(c51402177.damcon)
+	e3:SetTarget(c51402177.damtg)
+	e3:SetOperation(c51402177.damop)
+	c:RegisterEffect(e3)
+	--cannot attack
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetOperation(c51402177.atklimit)
+	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e5)
+end
+function c51402177.atklimit(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_ATTACK)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+	e:GetHandler():RegisterEffect(e1)
+end
+function c51402177.cfilter(c)
+	return c:IsFaceup() and c:IsCode(53569894)
+end
+function c51402177.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and Duel.CheckLPCost(c:GetControler(),500)
+		and Duel.IsExistingMatchingCard(c51402177.cfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+end
+function c51402177.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	Duel.PayLPCost(tp,500)
+end
+function c51402177.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and bit.band(bc:GetBattlePosition(),POS_DEFENSE)~=0
+end
+function c51402177.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local dam=math.floor(e:GetHandler():GetBattleTarget():GetBaseDefense()/2)
+	if dam<0 then dam=0 end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c51402177.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c52709508.lua
+++ b/706/c52709508.lua
@@ -1,0 +1,124 @@
+--A・ジェネクス・トライフォース
+---@param c Card
+function c52709508.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x2),aux.NonTuner(nil),1)
+	c:EnableReviveLimit()
+	--mat check
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_MATERIAL_CHECK)
+	e1:SetValue(c52709508.valcheck)
+	c:RegisterEffect(e1)
+	--synchro success
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetCondition(c52709508.regcon)
+	e2:SetOperation(c52709508.regop)
+	c:RegisterEffect(e2)
+	e2:SetLabelObject(e1)
+end
+function c52709508.valcheck(e,c)
+	local g=c:GetMaterial()
+	local att=0
+	local tc=g:GetFirst()
+	while tc do
+		if not tc:IsType(TYPE_TUNER) then
+			att=bit.bor(att,tc:GetAttribute())
+		end
+		tc=g:GetNext()
+	end
+	att=bit.band(att,0x15)
+	e:SetLabel(att)
+end
+function c52709508.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)
+		and e:GetLabelObject():GetLabel()~=0
+end
+function c52709508.regop(e,tp,eg,ep,ev,re,r,rp)
+	local att=e:GetLabelObject():GetLabel()
+	local c=e:GetHandler()
+	if bit.band(att,ATTRIBUTE_EARTH)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetTargetRange(0,1)
+		e1:SetValue(c52709508.aclimit)
+		e1:SetCondition(c52709508.actcon)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+		c:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(52709508,2))
+	end
+	if bit.band(att,ATTRIBUTE_FIRE)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(52709508,0))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_DAMAGE_STEP_END)
+		e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCondition(c52709508.damcon)
+		e1:SetTarget(c52709508.damtg)
+		e1:SetOperation(c52709508.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+		c:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(52709508,3))
+	end
+	if bit.band(att,ATTRIBUTE_LIGHT)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(52709508,1))
+		e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+		e1:SetType(EFFECT_TYPE_IGNITION)
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCountLimit(1)
+		e1:SetTarget(c52709508.sptg)
+		e1:SetOperation(c52709508.spop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+		c:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(52709508,4))
+	end
+end
+function c52709508.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c52709508.actcon(e)
+	return Duel.GetAttacker()==e:GetHandler()
+end
+function c52709508.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local t=Duel.GetAttackTarget()
+	if ev==1 then t=Duel.GetAttacker() end
+	e:SetLabel(t:GetAttack())
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c52709508.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(e:GetLabel())
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,e:GetLabel())
+end
+function c52709508.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end
+function c52709508.spfilter(c,e,tp)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+end
+function c52709508.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c52709508.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c52709508.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectTarget(tp,c52709508.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c52709508.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsAttribute(ATTRIBUTE_LIGHT) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+	end
+end

--- a/706/c52786469.lua
+++ b/706/c52786469.lua
@@ -1,0 +1,33 @@
+--ラヴァル・ウォリアー
+---@param c Card
+function c52786469.initial_effect(c)
+	--damage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(52786469,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCondition(c52786469.condition)
+	e1:SetTarget(c52786469.target)
+	e1:SetOperation(c52786469.operation)
+	c:RegisterEffect(e1)
+end
+function c52786469.condition(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	e:SetLabel(bc:GetAttack())
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c52786469.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(e:GetLabel())
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,e:GetLabel())
+end
+function c52786469.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetMatchingGroup(Card.IsSetCard,tp,LOCATION_GRAVE,0,nil,0x39):GetClassCount(Card.GetCode)<4 then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c53341729.lua
+++ b/706/c53341729.lua
@@ -15,10 +15,10 @@ function c53341729.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c53341729.disop(e,tp,eg,ep,ev,re,r,rp)
-	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
-	-- 临时添加被武僧洗回卡组的反转效果无效
+	local loc,eff=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_EFFECT)
+	-- 临时添加被武僧洗回卡组的反转效果无效 相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
 	local c=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_EFFECT):GetHandler()
-	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0))
+	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0) or ((loc==LOCATION_GRAVE or loc==LOCATION_REMOVED) and eff:GetLabel()==65703851))
 		and re:GetHandler():IsAttribute(ATTRIBUTE_LIGHT) then
 		Duel.NegateEffect(ev)
 	end

--- a/706/c53341729.lua
+++ b/706/c53341729.lua
@@ -1,0 +1,25 @@
+--閃光を吸い込むマジック・ミラー
+---@param c Card
+function c53341729.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetOperation(c53341729.disop)
+	c:RegisterEffect(e2)
+end
+function c53341729.disop(e,tp,eg,ep,ev,re,r,rp)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	-- 临时添加被武僧洗回卡组的反转效果无效
+	local c=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_EFFECT):GetHandler()
+	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0))
+		and re:GetHandler():IsAttribute(ATTRIBUTE_LIGHT) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/706/c53778229.lua
+++ b/706/c53778229.lua
@@ -1,0 +1,28 @@
+--墓地封印
+function c53778229.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c53778229.cost)
+	e1:SetOperation(c53778229.activate)
+	c:RegisterEffect(e1)
+end
+function c53778229.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function c53778229.activate(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetOperation(c53778229.disop)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c53778229.disop(e,tp,eg,ep,ev,re,r,rp)
+	local loc,eff=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_EFFECT)
+	if loc==LOCATION_GRAVE and eff:GetLabel()~=65703851 then --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+		Duel.NegateEffect(ev)
+	end
+end

--- a/706/c54702678.lua
+++ b/706/c54702678.lua
@@ -1,0 +1,67 @@
+--極戦機王ヴァルバロイド
+---@param c Card
+function c54702678.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcFunRep(c,c54702678.ffilter,5,true)
+	--extra attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_EXTRA_ATTACK)
+	e1:SetValue(1)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(54702678,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_BATTLED)
+	e2:SetCondition(c54702678.discon)
+	e2:SetOperation(c54702678.disop)
+	c:RegisterEffect(e2)
+	--damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(54702678,1))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetCondition(aux.dserodcon)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetTarget(c54702678.damtg)
+	e3:SetOperation(c54702678.damop)
+	c:RegisterEffect(e3)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	c:RegisterEffect(e4)
+end
+function c54702678.ffilter(c)
+	return c:IsFusionSetCard(0x16) and c:IsRace(RACE_MACHINE)
+end
+function c54702678.discon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttackTarget() and e:GetHandler()==Duel.GetAttacker()
+end
+function c54702678.disop(e,tp,eg,ep,ev,re,r,rp)
+	local bc=e:GetHandler():GetBattleTarget()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x57a0000)
+	bc:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(e:GetHandler())
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DISABLE_EFFECT)
+	e2:SetReset(RESET_EVENT+0x57a0000)
+	bc:RegisterEffect(e2)
+end
+function c54702678.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(1000)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)
+end
+function c54702678.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c54860010.lua
+++ b/706/c54860010.lua
@@ -1,0 +1,57 @@
+--ワーム・プリンス
+---@param c Card
+function c54860010.initial_effect(c)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(54860010,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c54860010.thtg)
+	e1:SetOperation(c54860010.thop)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(54860010,1))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_PHASE+PHASE_END)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c54860010.descon)
+	e2:SetTarget(c54860010.destg)
+	e2:SetOperation(c54860010.desop)
+	c:RegisterEffect(e2)
+end
+function c54860010.filter(c)
+	return c:IsSetCard(0x3e) and c:IsRace(RACE_REPTILE) and c:IsAbleToHand()
+end
+function c54860010.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c54860010.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c54860010.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c54860010.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c54860010.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x3e) and c:IsRace(RACE_REPTILE)
+end
+function c54860010.descon(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.IsExistingMatchingCard(c54860010.cfilter,tp,LOCATION_MZONE,0,1,e:GetHandler())
+end
+function c54860010.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetHandler(),1,0,0)
+end
+function c54860010.desop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+	end
+end

--- a/706/c6112401.lua
+++ b/706/c6112401.lua
@@ -99,7 +99,8 @@ function c6112401.eqlimit(e,c)
 	return g:GetCount()==1 and tc==c and c:IsSetCard(0x100d)
 end
 function c6112401.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsContains(e:GetHandler():GetEquipTarget())
+	local c = e:GetHandler()
+	return eg:IsContains(c:GetEquipTarget()) and c:GetControler() == c:GetEquipTarget():GetControler()
 end
 function c6112401.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/706/c62054060.lua
+++ b/706/c62054060.lua
@@ -1,0 +1,31 @@
+--平穏の賢者
+---@param c Card
+function c62054060.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(62054060,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetOperation(c62054060.operation)
+	c:RegisterEffect(e1)
+end
+function c62054060.operation(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetTargetRange(0,1)
+	e1:SetCondition(c62054060.accon)
+	e1:SetValue(c62054060.aclimit)
+	e1:SetLabel(Duel.GetTurnCount())
+	e1:SetReset(RESET_PHASE+PHASE_END,2)
+	Duel.RegisterEffect(e1,tp)
+end
+function c62054060.accon(e)
+	return e:GetLabel()~=Duel.GetTurnCount()
+end
+function c62054060.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_TRAP)
+end

--- a/706/c62315111.lua
+++ b/706/c62315111.lua
@@ -1,0 +1,32 @@
+--エーリアン・ハンター
+---@param c Card
+function c62315111.initial_effect(c)
+	--chain attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_BATTLED)
+	e1:SetOperation(c62315111.regop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(62315111,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c62315111.atcon)
+	e2:SetOperation(c62315111.atop)
+	c:RegisterEffect(e2)
+end
+function c62315111.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	if bc and bc:GetCounter(0x100e)>0 then
+		c:RegisterFlagEffect(62315111,RESET_PHASE+PHASE_DAMAGE,0,1)
+	end
+end
+function c62315111.atcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and c:IsChainAttackable() and c:GetFlagEffect(62315111)~=0
+end
+function c62315111.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c62742651.lua
+++ b/706/c62742651.lua
@@ -1,0 +1,54 @@
+--アーマード・サイキッカー
+---@param c Card
+function c62742651.initial_effect(c)
+	--summon with no tribute
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(62742651,0))
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SUMMON_PROC)
+	e1:SetCondition(c62742651.ntcon)
+	c:RegisterEffect(e1)
+	--damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(62742651,1))
+	e2:SetCategory(CATEGORY_DAMAGE+CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetTarget(c62742651.damtg)
+	e2:SetOperation(c62742651.damop)
+	c:RegisterEffect(e2)
+end
+function c62742651.ntfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_PSYCHO)
+end
+function c62742651.ntcon(e,c,minc)
+	if c==nil then return true end
+	return minc==0 and c:IsLevelAbove(5) and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c62742651.ntfilter,c:GetControler(),LOCATION_MZONE,0,1,nil)
+end
+function c62742651.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local bc=e:GetHandler():GetBattleTarget()
+	local dam=math.floor(bc:GetAttack()/2)
+	if dam<0 then dam=0 end
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,tp,dam)
+end
+function c62742651.spfilter(c,e,tp,atk)
+	return c:IsAttackBelow(atk) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c62742651.damop(e,tp,eg,ep,ev,re,r,rp)
+	local dam=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	if Duel.Damage(tp,dam,REASON_EFFECT)~=0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c62742651.spfilter),tp,LOCATION_GRAVE,0,nil,e,tp,dam)
+		if g:GetCount()~=0 and Duel.SelectYesNo(tp,aux.Stringid(62742651,2)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=g:Select(tp,1,1,nil)
+			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end

--- a/706/c63676256.lua
+++ b/706/c63676256.lua
@@ -1,0 +1,113 @@
+--バスター・ショットマン
+---@param c Card
+function c63676256.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(63676256,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c63676256.eqtg)
+	e1:SetOperation(c63676256.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(63676256,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c63676256.sptg)
+	e2:SetOperation(c63676256.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(aux.IsUnionState)
+	e3:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e3)
+	--eqlimit
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_UNION_LIMIT)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetValue(1)
+	c:RegisterEffect(e4)
+	--atk,def
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_EQUIP)
+	e5:SetCode(EFFECT_UPDATE_ATTACK)
+	e5:SetCondition(aux.IsUnionState)
+	e5:SetValue(-500)
+	c:RegisterEffect(e5)
+	local e6=e5:Clone()
+	e6:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e6)
+	--search
+	local e7=Effect.CreateEffect(c)
+	e7:SetDescription(aux.Stringid(63676256,2))
+	e7:SetCategory(CATEGORY_DESTROY)
+	e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e7:SetRange(LOCATION_SZONE)
+	e7:SetCode(EVENT_BATTLE_DESTROYING)
+	e7:SetCondition(c63676256.descon)
+	e7:SetTarget(c63676256.destg)
+	e7:SetOperation(c63676256.desop)
+	c:RegisterEffect(e7)
+end
+c63676256.old_union=true
+function c63676256.filter(c)
+	return c:IsFaceup() and c:GetUnionCount()==0
+end
+function c63676256.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c63676256.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(63676256)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c63676256.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c63676256.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(63676256,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c63676256.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c63676256.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c63676256.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(63676256)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(63676256,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c63676256.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c63676256.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and eg:GetCount()==1 and eg:GetFirst()==c:GetEquipTarget() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c63676256.dfilter(c,rac)
+	return c:IsFaceup() and c:IsRace(rac)
+end
+function c63676256.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local tc=eg:GetFirst():GetBattleTarget()
+	local desg=Duel.GetMatchingGroup(c63676256.dfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tc:GetRace())
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,desg,desg:GetCount(),0,0)
+end
+function c63676256.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst():GetBattleTarget()
+	local desg=Duel.GetMatchingGroup(c63676256.dfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil,tc:GetRace())
+	Duel.Destroy(desg,REASON_EFFECT)
+end

--- a/706/c64398890.lua
+++ b/706/c64398890.lua
@@ -1,0 +1,79 @@
+--六武衆－ヤイチ
+---@param c Card
+function c64398890.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(64398890,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c64398890.descon)
+	e1:SetCost(c64398890.descost)
+	e1:SetTarget(c64398890.destg)
+	e1:SetOperation(c64398890.desop)
+	c:RegisterEffect(e1)
+	--Destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTarget(c64398890.desreptg)
+	e2:SetOperation(c64398890.desrepop)
+	c:RegisterEffect(e2)
+end
+function c64398890.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x103d) and not c:IsCode(64398890)
+end
+function c64398890.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c64398890.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c64398890.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetAttackAnnouncedCount()==0 end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
+	e:GetHandler():RegisterEffect(e1,true)
+end
+function c64398890.desfilter(c)
+	return c:IsFacedown()
+end
+function c64398890.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and c64398890.desfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c64398890.desfilter,tp,LOCATION_SZONE,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c64398890.desfilter,tp,LOCATION_SZONE,LOCATION_SZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c64398890.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if not Duel.IsExistingMatchingCard(c64398890.cfilter,tp,LOCATION_MZONE,0,1,nil) then return end
+	if tc:IsFacedown() and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c64398890.repfilter(c,e)
+	return c:IsFaceup() and c:IsSetCard(0x103d)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+end
+function c64398890.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsReason(REASON_REPLACE) and c:IsOnField() and c:IsFaceup()
+		and Duel.IsExistingMatchingCard(c64398890.repfilter,tp,LOCATION_MZONE,0,1,c,e) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local g=Duel.SelectMatchingCard(tp,c64398890.repfilter,tp,LOCATION_MZONE,0,1,1,c,e)
+		e:SetLabelObject(g:GetFirst())
+		g:GetFirst():SetStatus(STATUS_DESTROY_CONFIRMED,true)
+		return true
+	else return false end
+end
+function c64398890.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
+	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)
+end

--- a/706/c65260293.lua
+++ b/706/c65260293.lua
@@ -1,0 +1,34 @@
+--エレメント・マジシャン
+---@param c Card
+function c65260293.initial_effect(c)
+	--control
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_CANNOT_CHANGE_CONTROL)
+	e1:SetCondition(c65260293.ctlcon)
+	c:RegisterEffect(e1)
+	--chain attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(65260293,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c65260293.atcon)
+	e2:SetOperation(c65260293.atop)
+	c:RegisterEffect(e2)
+end
+function c65260293.filter(c,att)
+	return c:IsFaceup() and c:IsAttribute(att)
+end
+function c65260293.ctlcon(e)
+	return Duel.IsExistingMatchingCard(c65260293.filter,0,LOCATION_MZONE,LOCATION_MZONE,1,nil,ATTRIBUTE_WATER)
+end
+function c65260293.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+		and Duel.IsExistingMatchingCard(c65260293.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,ATTRIBUTE_WIND)
+end
+function c65260293.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c65403020.lua
+++ b/706/c65403020.lua
@@ -1,0 +1,24 @@
+--エンド・オブ・アヌビス
+function c65403020.initial_effect(c)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetCondition(c65403020.condition)
+	e1:SetOperation(c65403020.operation)
+	c:RegisterEffect(e1)
+end
+function c65403020.gfilter(c)
+	return c:IsLocation(LOCATION_GRAVE)
+end
+function c65403020.condition(e,tp,eg,ep,ev,re,r,rp)
+	local loc,eff=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_EFFECT)
+	if loc==LOCATION_GRAVE and eff:GetLabel()~=65703851 then return true end --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return g and g:IsExists(c65403020.gfilter,1,nil)
+end
+function c65403020.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end

--- a/706/c65685470.lua
+++ b/706/c65685470.lua
@@ -1,0 +1,117 @@
+--六武衆の御霊代
+---@param c Card
+function c65685470.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(65685470,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c65685470.eqtg)
+	e1:SetOperation(c65685470.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(65685470,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c65685470.sptg)
+	e2:SetOperation(c65685470.spop)
+	c:RegisterEffect(e2)
+	--Atk up
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetValue(500)
+	e3:SetCondition(aux.IsUnionState)
+	c:RegisterEffect(e3)
+	--Def up
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_EQUIP)
+	e4:SetCode(EFFECT_UPDATE_DEFENSE)
+	e4:SetValue(500)
+	e4:SetCondition(aux.IsUnionState)
+	c:RegisterEffect(e4)
+	--destroy sub
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_EQUIP)
+	e5:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e5:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e5:SetCondition(aux.IsUnionState)
+	e5:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e5)
+	--draw
+	local e6=Effect.CreateEffect(c)
+	e6:SetDescription(aux.Stringid(65685470,2))
+	e6:SetCategory(CATEGORY_DRAW)
+	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e6:SetCode(EVENT_BATTLE_DESTROYING)
+	e6:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e6:SetRange(LOCATION_SZONE)
+	e6:SetCondition(c65685470.drcon)
+	e6:SetTarget(c65685470.drtg)
+	e6:SetOperation(c65685470.drop)
+	c:RegisterEffect(e6)
+	--eqlimit
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetCode(EFFECT_UNION_LIMIT)
+	e7:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e7:SetValue(c65685470.eqlimit)
+	c:RegisterEffect(e7)
+end
+c65685470.old_union=true
+function c65685470.eqlimit(e,c)
+	return c:IsSetCard(0x103d)
+end
+function c65685470.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x103d) and c:GetUnionCount()==0
+end
+function c65685470.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c65685470.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(65685470)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c65685470.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c65685470.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(65685470,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c65685470.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c65685470.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c65685470.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(65685470)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(65685470,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c65685470.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c65685470.drcon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and c:GetEquipTarget()==eg:GetFirst() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c65685470.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c65685470.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/706/c65703851.lua
+++ b/706/c65703851.lua
@@ -1,0 +1,21 @@
+--透破抜き
+function c65703851.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCondition(c65703851.condition)
+	e1:SetTarget(aux.nbtg)
+	e1:SetOperation(c65703851.activate)
+	c:RegisterEffect(e1)
+end
+function c65703851.condition(e,tp,eg,ep,ev,re,r,rp)
+	local loc,eff=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_EFFECT)
+	return (loc==LOCATION_HAND or loc==LOCATION_GRAVE) and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev) and eff:GetLabel()~=65703851 --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+end
+function c65703851.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Remove(eg,POS_FACEUP,REASON_EFFECT)
+	end
+end

--- a/706/c6588580.lua
+++ b/706/c6588580.lua
@@ -1,0 +1,41 @@
+--サーマル・ジェネクス
+---@param c Card
+function c6588580.initial_effect(c)
+	aux.AddMaterialCodeList(c,68505803)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsCode,68505803),aux.NonTuner(Card.IsAttribute,ATTRIBUTE_FIRE),1)
+	c:EnableReviveLimit()
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetValue(c6588580.val)
+	c:RegisterEffect(e1)
+	--damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(6588580,0))
+	e2:SetCategory(CATEGORY_DAMAGE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetTarget(c6588580.damtg)
+	e2:SetOperation(c6588580.damop)
+	c:RegisterEffect(e2)
+end
+function c6588580.val(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_FIRE)*200
+end
+function c6588580.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function c6588580.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local d=Duel.GetMatchingGroupCount(Card.IsSetCard,tp,LOCATION_GRAVE,0,nil,0x2)*200
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c71106375.lua
+++ b/706/c71106375.lua
@@ -1,0 +1,31 @@
+--ジュラック・イグアノン
+---@param c Card
+function c71106375.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(71106375,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c71106375.thtg)
+	e1:SetOperation(c71106375.thop)
+	c:RegisterEffect(e1)
+end
+function c71106375.filter(c)
+	return c:IsFacedown() and c:IsAbleToHand()
+end
+function c71106375.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and c71106375.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c71106375.filter,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+	local g=Duel.SelectTarget(tp,c71106375.filter,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c71106375.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFacedown() and tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	end
+end

--- a/706/c73483491.lua
+++ b/706/c73483491.lua
@@ -1,0 +1,41 @@
+--レアル・ジェネクス・ヴィンディカイト
+---@param c Card
+function c73483491.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x2),aux.NonTuner(Card.IsAttribute,ATTRIBUTE_WIND),1)
+	c:EnableReviveLimit()
+	--untargetable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e1:SetValue(aux.imval1)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(73483491,0))
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetTarget(c73483491.thtg)
+	e2:SetOperation(c73483491.thop)
+	c:RegisterEffect(e2)
+end
+function c73483491.filter(c)
+	return c:IsSetCard(0x2) and c:IsAbleToHand()
+end
+function c73483491.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c73483491.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c73483491.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c73483491.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/706/c74440055.lua
+++ b/706/c74440055.lua
@@ -1,0 +1,27 @@
+--サボウ・ファイター
+---@param c Card
+function c74440055.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(74440055,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c74440055.target)
+	e1:SetOperation(c74440055.operation)
+	c:RegisterEffect(e1)
+end
+function c74440055.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,tp,0)
+end
+function c74440055.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,74440056,0,TYPES_TOKEN_MONSTER,500,500,1,RACE_PLANT,ATTRIBUTE_EARTH,POS_FACEUP_DEFENSE,1-tp) then
+		local token=Duel.CreateToken(tp,74440056)
+		Duel.SpecialSummon(token,0,tp,1-tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/706/c76925842.lua
+++ b/706/c76925842.lua
@@ -1,0 +1,47 @@
+--ダーク・パーシアス
+---@param c Card
+function c76925842.initial_effect(c)
+	--atk
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(c76925842.atkval)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(76925842,0))
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetCost(c76925842.drcost)
+	e2:SetTarget(c76925842.drtg)
+	e2:SetOperation(c76925842.drop)
+	c:RegisterEffect(e2)
+end
+function c76925842.atkval(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_DARK)*100
+end
+function c76925842.rfilter(c)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToRemoveAsCost()
+end
+function c76925842.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c76925842.rfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c76925842.rfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c76925842.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c76925842.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/706/c78010363.lua
+++ b/706/c78010363.lua
@@ -1,37 +1,31 @@
---氷結界の大僧正
+--黒き森のウィッチ
 function c78010363.initial_effect(c)
-	--to defense
+	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(78010363,0))
-	e1:SetCategory(CATEGORY_POSITION)
-	e1:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
-	e1:SetCode(EVENT_SUMMON_SUCCESS)
-	e1:SetTarget(c78010363.potg)
-	e1:SetOperation(c78010363.poop)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetCondition(c78010363.condition)
+	e1:SetTarget(c78010363.target)
+	e1:SetOperation(c78010363.operation)
 	c:RegisterEffect(e1)
-	local e2=e1:Clone()
-	e2:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
-	c:RegisterEffect(e2)
-	--special summon
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetTargetRange(LOCATION_MZONE,0)
-	e3:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
-	e3:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x2f))
-	e3:SetValue(c78010363.indval)
-	c:RegisterEffect(e3)
 end
-function c78010363.potg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAttackPos() end
-	Duel.SetOperationInfo(0,CATEGORY_POSITION,e:GetHandler(),1,0,0)
+function c78010363.condition(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
-function c78010363.poop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if c:IsFaceup() and c:IsAttackPos() and c:IsRelateToEffect(e) then
-		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
+function c78010363.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c78010363.filter(c)
+	return c:IsDefenseBelow(1500) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c78010363.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c78010363.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
 	end
-end
-function c78010363.indval(e,re,rp)
-	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP)
 end

--- a/706/c78422252.lua
+++ b/706/c78422252.lua
@@ -1,0 +1,62 @@
+--XX－セイバー フラムナイト
+---@param c Card
+function c78422252.initial_effect(c)
+	--negate attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(78422252,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_NO_TURN_RESET)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c78422252.condition)
+	e1:SetTarget(c78422252.target)
+	e1:SetOperation(c78422252.operation)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(78422252,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c78422252.spcon)
+	e2:SetTarget(c78422252.sptg)
+	e2:SetOperation(c78422252.spop)
+	c:RegisterEffect(e2)
+end
+function c78422252.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp)
+end
+function c78422252.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c78422252.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+end
+function c78422252.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local a=Duel.GetAttacker()
+	local d=Duel.GetAttackTarget()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and bit.band(d:GetBattlePosition(),POS_DEFENSE)~=0
+end
+function c78422252.filter(c,e,tp)
+	return c:IsSetCard(0x100d) and c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c78422252.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c78422252.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c78422252.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c78422252.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c78422252.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/706/c80367387.lua
+++ b/706/c80367387.lua
@@ -1,0 +1,70 @@
+--コアキメイル・ベルグザーク
+---@param c Card
+function c80367387.initial_effect(c)
+	aux.AddCodeList(c,36623431)
+	--cost
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c80367387.mtcon)
+	e1:SetOperation(c80367387.mtop)
+	c:RegisterEffect(e1)
+	--chain attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(80367387,3))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c80367387.atcon)
+	e2:SetOperation(c80367387.atop)
+	c:RegisterEffect(e2)
+end
+function c80367387.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c80367387.cfilter1(c)
+	return c:IsCode(36623431) and c:IsAbleToGraveAsCost()
+end
+function c80367387.cfilter2(c)
+	return c:IsType(TYPE_MONSTER) and c:IsRace(RACE_WARRIOR) and not c:IsPublic()
+end
+function c80367387.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
+	local g1=Duel.GetMatchingGroup(c80367387.cfilter1,tp,LOCATION_HAND,0,nil)
+	local g2=Duel.GetMatchingGroup(c80367387.cfilter2,tp,LOCATION_HAND,0,nil)
+	local select=2
+	Duel.Hint(HINT_SELECTMSG,tp,0)
+	if g1:GetCount()>0 and g2:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,0),aux.Stringid(80367387,1),aux.Stringid(80367387,2))
+	elseif g1:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,0),aux.Stringid(80367387,2))
+		if select==1 then select=2 end
+	elseif g2:GetCount()>0 then
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,1),aux.Stringid(80367387,2))+1
+	else
+		select=Duel.SelectOption(tp,aux.Stringid(80367387,2))
+		select=2
+	end
+	if select==0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=g1:Select(tp,1,1,nil)
+		Duel.SendtoGrave(g,REASON_COST)
+	elseif select==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONFIRM)
+		local g=g2:Select(tp,1,1,nil)
+		Duel.ConfirmCards(1-tp,g)
+		Duel.ShuffleHand(tp)
+	else
+		Duel.Destroy(c,REASON_COST)
+	end
+end
+function c80367387.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+end
+function c80367387.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end

--- a/706/c80637190.lua
+++ b/706/c80637190.lua
@@ -1,0 +1,37 @@
+--スパイダー・スパイダー
+---@param c Card
+function c80637190.initial_effect(c)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(80637190,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(c80637190.spcon)
+	e2:SetTarget(c80637190.sptg)
+	e2:SetOperation(c80637190.spop)
+	c:RegisterEffect(e2)
+end
+function c80637190.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetBattleTarget()
+	return aux.dserodcon(e,tp,eg,ep,ev,re,r,rp) and bit.band(tc:GetBattlePosition(),POS_DEFENSE)~=0
+end
+function c80637190.filter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsRace(RACE_INSECT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c80637190.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c80637190.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c80637190.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c80637190.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c80637190.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsRace(RACE_INSECT) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/706/c80651316.lua
+++ b/706/c80651316.lua
@@ -1,0 +1,50 @@
+--エヴォルダー・ケラト
+---@param c Card
+function c80651316.initial_effect(c)
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(aux.evospcon)
+	e1:SetOperation(c80651316.atkop)
+	c:RegisterEffect(e1)
+end
+function c80651316.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(200)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+	c:RegisterEffect(e1)
+	--search
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(80651316,0))
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetTarget(c80651316.schtg)
+	e2:SetOperation(c80651316.schop)
+	e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+	c:RegisterEffect(e2)
+end
+function c80651316.sfilter(c)
+	return c:IsSetCard(0x304e) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c80651316.schtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c80651316.sfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c80651316.schop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c80651316.sfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/706/c82841979.lua
+++ b/706/c82841979.lua
@@ -1,0 +1,72 @@
+--大和神
+---@param c Card
+function c82841979.initial_effect(c)
+	c:EnableReviveLimit()
+	--spirit return
+	aux.EnableSpiritReturn(c,EVENT_SPSUMMON_SUCCESS)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c82841979.spcon)
+	e2:SetTarget(c82841979.sptg)
+	e2:SetOperation(c82841979.spop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(82841979,0))
+	e4:SetCategory(CATEGORY_DESTROY)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e4:SetCode(EVENT_DAMAGE_STEP_END)
+	e4:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e4:SetCondition(aux.dserodcon)
+	e4:SetTarget(c82841979.destg)
+	e4:SetOperation(c82841979.desop)
+	c:RegisterEffect(e4)
+end
+function c82841979.spfilter(c)
+	return c:IsType(TYPE_SPIRIT) and c:IsAbleToRemoveAsCost()
+end
+function c82841979.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
+		Duel.IsExistingMatchingCard(c82841979.spfilter,c:GetControler(),LOCATION_GRAVE,0,1,nil)
+end
+function c82841979.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
+	local g=Duel.GetMatchingGroup(c82841979.spfilter,tp,LOCATION_GRAVE,0,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local tc=g:SelectUnselect(nil,tp,false,true,1,1)
+	if tc then
+		e:SetLabelObject(tc)
+		return true
+	else return false end
+end
+function c82841979.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=e:GetLabelObject()
+	Duel.Remove(g,POS_FACEUP,REASON_SPSUMMON)
+end
+function c82841979.filter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c82841979.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsControler(1-tp) and c82841979.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c82841979.filter,tp,0,LOCATION_ONFIELD,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c82841979.filter,tp,0,LOCATION_ONFIELD,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c82841979.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/706/c84055227.lua
+++ b/706/c84055227.lua
@@ -1,0 +1,28 @@
+--ゲイシャドウ
+---@param c Card
+function c84055227.initial_effect(c)
+	c:EnableCounterPermit(0x1)
+	--add counter
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(84055227,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetOperation(c84055227.operation)
+	c:RegisterEffect(e1)
+	--attackup
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(c84055227.attackup)
+	c:RegisterEffect(e2)
+end
+function c84055227.operation(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():AddCounter(0x1,1)
+end
+function c84055227.attackup(e,c)
+	return c:GetCounter(0x1)*200
+end

--- a/706/c84313685.lua
+++ b/706/c84313685.lua
@@ -1,0 +1,110 @@
+--ヴァイロン・テセラクト
+---@param c Card
+function c84313685.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(84313685,0))
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c84313685.eqtg)
+	e1:SetOperation(c84313685.eqop)
+	c:RegisterEffect(e1)
+	--unequip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(84313685,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(aux.IsUnionState)
+	e2:SetTarget(c84313685.sptg)
+	e2:SetOperation(c84313685.spop)
+	c:RegisterEffect(e2)
+	--destroy sub
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e3:SetCondition(aux.IsUnionState)
+	e3:SetValue(aux.UnionReplaceFilter)
+	c:RegisterEffect(e3)
+	--special summon
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(84313685,2))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c84313685.gspcon)
+	e4:SetTarget(c84313685.gsptg)
+	e4:SetOperation(c84313685.gspop)
+	c:RegisterEffect(e4)
+	--eqlimit
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_UNION_LIMIT)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e5:SetValue(c84313685.eqlimit)
+	c:RegisterEffect(e5)
+end
+c84313685.old_union=true
+function c84313685.eqlimit(e,c)
+	return c:IsSetCard(0x30)
+end
+function c84313685.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x30) and c:GetUnionCount()==0
+end
+function c84313685.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c84313685.filter(chkc) end
+	if chk==0 then return e:GetHandler():GetFlagEffect(84313685)==0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c84313685.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c84313685.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(84313685,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c84313685.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	if not tc:IsRelateToEffect(e) or not c84313685.filter(tc) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	if not Duel.Equip(tp,c,tc,false) then return end
+	aux.SetUnionState(c)
+end
+function c84313685.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(84313685)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():RegisterFlagEffect(84313685,RESET_EVENT+0x7e0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c84313685.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP_ATTACK)
+end
+function c84313685.gspcon(e,tp,eg,ep,ev,re,r,rp)
+	local c = e:GetHandler()
+	return aux.IsUnionState(e) and c:GetEquipTarget()==eg:GetFirst() and c:GetControler() == c:GetEquipTarget():GetControler()
+end
+function c84313685.gfilter(c,e,tp)
+	return c:IsLevelBelow(4) and c:IsSetCard(0x30) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c84313685.gsptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c84313685.gfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c84313685.gfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c84313685.gfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c84313685.gspop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/706/c86170989.lua
+++ b/706/c86170989.lua
@@ -1,0 +1,67 @@
+--ファルシオンβ
+---@param c Card
+function c86170989.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(86170989,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c86170989.target)
+	e1:SetOperation(c86170989.operation)
+	c:RegisterEffect(e1)
+end
+function c86170989.filter1(c)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAttackBelow(1200) and c:IsAbleToGrave()
+end
+function c86170989.filter2(c,e,tp)
+	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAttackBelow(1200)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c86170989.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c86170989.filter2(chkc,e,tp) end
+	if chk==0 then return true end
+	local op=0
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(86170989,0))
+	local t1=Duel.IsExistingMatchingCard(c86170989.filter1,tp,LOCATION_DECK,0,1,nil)
+	local t2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c86170989.filter2,tp,LOCATION_GRAVE,0,1,nil,e,tp)
+	if t1 and t2 then
+		op=Duel.SelectOption(tp,aux.Stringid(86170989,1),aux.Stringid(86170989,2))+1
+	elseif t1 then
+		Duel.SelectOption(tp,aux.Stringid(86170989,1))
+		op=1
+	elseif t2 then
+		Duel.SelectOption(tp,aux.Stringid(86170989,2))
+		op=2
+	end
+	e:SetLabel(op)
+	if op==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g=Duel.SelectTarget(tp,c86170989.filter2,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	elseif op==1 then
+		Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+		e:SetProperty(0)
+		e:SetCategory(CATEGORY_TOGRAVE)
+	else
+		e:SetProperty(0)
+		e:SetCategory(0)
+	end
+end
+function c86170989.operation(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetLabel()==2 then
+		local tc=Duel.GetFirstTarget()
+		if tc and tc:IsRelateToEffect(e) then
+			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+		end
+	elseif e:GetLabel()==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=Duel.SelectMatchingCard(tp,c86170989.filter1,tp,LOCATION_DECK,0,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.SendtoGrave(g,REASON_EFFECT)
+		end
+	end
+end

--- a/706/c86321248.lua
+++ b/706/c86321248.lua
@@ -1,0 +1,94 @@
+--古代の機械合成獣
+---@param c Card
+function c86321248.initial_effect(c)
+	aux.AddCodeList(c,41172955,86445415,13839120)
+	--mat check
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_MATERIAL_CHECK)
+	e1:SetValue(c86321248.valcheck)
+	c:RegisterEffect(e1)
+	--summon success
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetCondition(c86321248.regcon)
+	e2:SetOperation(c86321248.regop)
+	c:RegisterEffect(e2)
+	e2:SetLabelObject(e1)
+end
+function c86321248.valcheck(e,c)
+	local g=c:GetMaterial()
+	local flag=0
+	local tc=g:GetFirst()
+	while tc do
+		local code=tc:GetCode()
+		if code==41172955 then flag=bit.bor(flag,0x1)
+		elseif code==86445415 then flag=bit.bor(flag,0x2)
+		elseif code==13839120 then flag=bit.bor(flag,0x4)
+		end
+		tc=g:GetNext()
+	end
+	e:SetLabel(flag)
+end
+function c86321248.regcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_ADVANCE)
+end
+function c86321248.regop(e,tp,eg,ep,ev,re,r,rp)
+	local flag=e:GetLabelObject():GetLabel()
+	local c=e:GetHandler()
+	if bit.band(flag,0x1)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(300)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+	if bit.band(flag,0x2)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(86321248,0))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DAMAGE)
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCondition(c86321248.damcon1)
+		e1:SetTarget(c86321248.damtg1)
+		e1:SetOperation(c86321248.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+	if bit.band(flag,0x4)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(86321248,1))
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCode(EVENT_DAMAGE_STEP_END)
+		e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+		e1:SetCondition(aux.dserodcon)
+		e1:SetTarget(c86321248.damtg2)
+		e1:SetOperation(c86321248.damop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1)
+	end
+end
+function c86321248.damcon1(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and Duel.GetAttackTarget()==nil
+end
+function c86321248.damtg1(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+end
+function c86321248.damtg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(700)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,700)
+end
+function c86321248.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c87350908.lua
+++ b/706/c87350908.lua
@@ -1,0 +1,25 @@
+--マスクド・チョッパー
+---@param c Card
+function c87350908.initial_effect(c)
+	--damage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(87350908,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetTarget(c87350908.damtg)
+	e1:SetOperation(c87350908.damop)
+	c:RegisterEffect(e1)
+end
+function c87350908.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(2000)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,2000)
+end
+function c87350908.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/706/c87622767.lua
+++ b/706/c87622767.lua
@@ -1,0 +1,38 @@
+--ファイナルサイコオーガ
+---@param c Card
+function c87622767.initial_effect(c)
+	--salvage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(87622767,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetCost(c87622767.thcost)
+	e1:SetTarget(c87622767.thtg)
+	e1:SetOperation(c87622767.thop)
+	c:RegisterEffect(e1)
+end
+function c87622767.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLPCost(tp,800) end
+	Duel.PayLPCost(tp,800)
+end
+function c87622767.filter(c)
+	return c:IsRace(RACE_PSYCHO) and c:IsAbleToHand()
+end
+function c87622767.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c87622767.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c87622767.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c87622767.filter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c87622767.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and tc:IsRace(RACE_PSYCHO) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end

--- a/706/c88472456.lua
+++ b/706/c88472456.lua
@@ -1,0 +1,28 @@
+--ダーク・ヒーロー ゾンバイア
+---@param c Card
+function c88472456.initial_effect(c)
+	--cannot direct attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	c:RegisterEffect(e1)
+	--atkdown
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetOperation(c88472456.atkop)
+	c:RegisterEffect(e2)
+end
+function c88472456.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(-200)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+	c:RegisterEffect(e1)
+end

--- a/706/c89194033.lua
+++ b/706/c89194033.lua
@@ -1,0 +1,46 @@
+--聖獣セルケト
+---@param c Card
+function c89194033.initial_effect(c)
+	--selfdestroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_SELF_DESTROY)
+	e1:SetCondition(c89194033.descon)
+	c:RegisterEffect(e1)
+	--redirect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_BATTLE_DESTROY_REDIRECT)
+	e2:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e2)
+	--atkup
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(89194033,0))
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e3:SetCondition(aux.dserodcon)
+	e3:SetOperation(c89194033.atkop)
+	c:RegisterEffect(e3)
+end
+function c89194033.desfilter(c)
+	return c:IsFaceup() and c:IsCode(29762407)
+end
+function c89194033.descon(e)
+	return not Duel.IsExistingMatchingCard(c89194033.desfilter,e:GetHandler():GetControler(),LOCATION_SZONE,0,1,nil)
+end
+function c89194033.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsFaceup() and e:GetHandler():IsRelateToBattle()
+end
+function c89194033.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(500)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+	c:RegisterEffect(e1)
+end

--- a/706/c89567993.lua
+++ b/706/c89567993.lua
@@ -1,0 +1,33 @@
+--アマゾネス訓練生
+---@param c Card
+function c89567993.initial_effect(c)
+	--to deck
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_BATTLE_DESTROY_REDIRECT)
+	e1:SetValue(LOCATION_DECKBOT)
+	c:RegisterEffect(e1)
+	--atkup
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(89567993,0))
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetOperation(c89567993.atkop)
+	c:RegisterEffect(e2)
+end
+function c89567993.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFaceup() and c:IsRelateToBattle() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(200)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+		c:RegisterEffect(e1)
+	end
+end

--- a/706/c90397998.lua
+++ b/706/c90397998.lua
@@ -1,0 +1,79 @@
+--六武衆－カモン
+---@param c Card
+function c90397998.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(90397998,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c90397998.descon)
+	e1:SetCost(c90397998.descost)
+	e1:SetTarget(c90397998.destg)
+	e1:SetOperation(c90397998.desop)
+	c:RegisterEffect(e1)
+	--Destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTarget(c90397998.desreptg)
+	e2:SetOperation(c90397998.desrepop)
+	c:RegisterEffect(e2)
+end
+function c90397998.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x103d) and not c:IsCode(90397998)
+end
+function c90397998.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c90397998.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c90397998.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetAttackAnnouncedCount()==0 end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
+	e:GetHandler():RegisterEffect(e1,true)
+end
+function c90397998.desfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c90397998.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c90397998.desfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c90397998.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c90397998.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c90397998.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if not Duel.IsExistingMatchingCard(c90397998.cfilter,tp,LOCATION_MZONE,0,1,nil) then return end
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c90397998.repfilter(c,e)
+	return c:IsFaceup() and c:IsSetCard(0x103d)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+end
+function c90397998.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsReason(REASON_REPLACE) and c:IsOnField() and c:IsFaceup()
+		and Duel.IsExistingMatchingCard(c90397998.repfilter,tp,LOCATION_MZONE,0,1,c,e) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local g=Duel.SelectMatchingCard(tp,c90397998.repfilter,tp,LOCATION_MZONE,0,1,1,c,e)
+		e:SetLabelObject(g:GetFirst())
+		g:GetFirst():SetStatus(STATUS_DESTROY_CONFIRMED,true)
+		return true
+	else return false end
+end
+function c90397998.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
+	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)
+end

--- a/706/c93130021.lua
+++ b/706/c93130021.lua
@@ -1,0 +1,154 @@
+--ビクトリー・バイパー XX03
+---@param c Card
+function c93130021.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(93130021,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetTarget(c93130021.target)
+	e1:SetOperation(c93130021.operation)
+	c:RegisterEffect(e1)
+end
+function c93130021.condition(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsRelateToBattle() and c:GetBattleTarget():IsType(TYPE_MONSTER)
+end
+function c93130021.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c93130021.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c93130021.filter(chkc) end
+	if chk==0 then return true end
+	local c=e:GetHandler()
+	local t1=Duel.IsExistingTarget(c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+	local t2=Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,TYPES_TOKEN_MONSTER,c:GetAttack(),c:GetDefense(),c:GetLevel(),c:GetRace(),c:GetAttribute())
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(93130021,0))
+	local op=-1
+
+	if c:IsOnField() then
+		if t1 and t2 then
+			op=Duel.SelectOption(tp,aux.Stringid(93130021,1),aux.Stringid(93130021,2),aux.Stringid(93130021,3))
+		elseif t1 then
+			op=Duel.SelectOption(tp,aux.Stringid(93130021,1),aux.Stringid(93130021,2))
+		elseif t2 then
+			op=Duel.SelectOption(tp,aux.Stringid(93130021,1),aux.Stringid(93130021,3))
+			if op==1 then op=2 end
+		else
+			op=Duel.SelectOption(tp,aux.Stringid(93130021,1))
+		end
+	else
+		if t1 then
+			op=Duel.SelectOption(tp,aux.Stringid(93130021,2))
+			if op==0 then op=1 end
+		end
+	end
+
+	e:SetLabel(op)
+	if op==1 then
+		e:SetCategory(CATEGORY_DESTROY)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		local g=Duel.SelectTarget(tp,c93130021.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	elseif op==2 then
+		e:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
+		e:SetProperty(0)
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+		Duel.SetOperationInfo(0,CATEGORY_TOKEN,nil,1,0,0)
+	else
+		e:SetCategory(CATEGORY_ATKCHANGE)
+		e:SetProperty(0)
+	end
+end
+function c93130021.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if e:GetLabel()==1 then
+		local tc=Duel.GetFirstTarget()
+		if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+			Duel.Destroy(tc,REASON_EFFECT)
+		end
+	elseif e:GetLabel()==2 then
+		local atk=c:GetAttack()
+		local def=c:GetDefense()
+		local lv=c:GetLevel()
+		local race=c:GetRace()
+		local att=c:GetAttribute()
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not c:IsRelateToEffect(e) or c:IsFacedown()
+			or not Duel.IsPlayerCanSpecialSummonMonster(tp,93130022,0,TYPES_TOKEN_MONSTER,atk,def,lv,race,att) then return end
+		local token=Duel.CreateToken(tp,93130022)
+		c:CreateRelation(token,RESET_EVENT+RESETS_STANDARD)
+		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE,EFFECT_FLAG2_OPTION)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetValue(c93130021.tokenatk)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD)
+		token:RegisterEffect(e1,true)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_SET_DEFENSE_FINAL)
+		e2:SetValue(c93130021.tokendef)
+		token:RegisterEffect(e2,true)
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_CHANGE_LEVEL)
+		e3:SetValue(c93130021.tokenlv)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD)
+		token:RegisterEffect(e3,true)
+		local e4=Effect.CreateEffect(c)
+		e4:SetType(EFFECT_TYPE_SINGLE)
+		e4:SetCode(EFFECT_CHANGE_RACE)
+		e4:SetValue(c93130021.tokenrace)
+		e4:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD)
+		token:RegisterEffect(e4,true)
+		local e5=Effect.CreateEffect(c)
+		e5:SetType(EFFECT_TYPE_SINGLE)
+		e5:SetCode(EFFECT_CHANGE_ATTRIBUTE)
+		e5:SetValue(c93130021.tokenatt)
+		e5:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD)
+		token:RegisterEffect(e5,true)
+		local e6=Effect.CreateEffect(c)
+		e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e6:SetCode(EVENT_ADJUST)
+		e6:SetRange(LOCATION_MZONE)
+		e6:SetCondition(c93130021.tokendescon)
+		e6:SetOperation(c93130021.tokendesop)
+		e6:SetReset(RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD)
+		token:RegisterEffect(e6,true)
+		Duel.SpecialSummonComplete()
+	elseif e:GetLabel()==0 then
+		if c:IsRelateToEffect(e) and c:IsFaceup() then
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(400)
+			e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_DISABLE)
+			c:RegisterEffect(e1)
+		end
+	end
+end
+function c93130021.tokenatk(e,c)
+	return e:GetOwner():GetAttack()
+end
+function c93130021.tokendef(e,c)
+	return e:GetOwner():GetDefense()
+end
+function c93130021.tokenlv(e,c)
+	return e:GetOwner():GetLevel()
+end
+function c93130021.tokenrace(e,c)
+	return e:GetOwner():GetRace()
+end
+function c93130021.tokenatt(e,c)
+	return e:GetOwner():GetAttribute()
+end
+function c93130021.tokendescon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetOwner():IsRelateToCard(e:GetHandler())
+end
+function c93130021.tokendesop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetHandler(),REASON_RULE)
+end

--- a/706/c94538053.lua
+++ b/706/c94538053.lua
@@ -15,9 +15,10 @@ function c94538053.initial_effect(c)
 	e2:SetDescription(aux.Stringid(94538053,0))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCategory(CATEGORY_ATKCHANGE)
-	e2:SetCode(EVENT_BATTLE_DESTROYING)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetCondition(c94538053.atkcon)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
+	e2:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e2:SetCondition(aux.dserodcon)
+	e2:SetRange(LOCATION_MZONE + LOCATION_GRAVE + LOCATION_REMOVED)
 	e2:SetOperation(c94538053.atkop)
 	c:RegisterEffect(e2)
 end
@@ -25,9 +26,6 @@ function c94538053.condtion(e)
 	local ph=Duel.GetCurrentPhase()
 	return (ph==PHASE_DAMAGE or ph==PHASE_DAMAGE_CAL)
 		and Duel.GetAttacker()==e:GetHandler() and Duel.GetAttackTarget()~=nil
-end
-function c94538053.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsRelateToBattle() and e:GetHandler():IsFaceup()
 end
 function c94538053.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/706/c95519486.lua
+++ b/706/c95519486.lua
@@ -1,0 +1,75 @@
+--六武衆－ザンジ
+---@param c Card
+function c95519486.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(95519486,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetCondition(c95519486.descon)
+	e1:SetTarget(c95519486.destg)
+	e1:SetOperation(c95519486.desop)
+	c:RegisterEffect(e1)
+	--Destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTarget(c95519486.desreptg)
+	e2:SetOperation(c95519486.desrepop)
+	c:RegisterEffect(e2)
+	--临时增加一个被破坏回卡组必发效果来还原被人鱼洗回卡组也能发动的旧裁定
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(95519486,0))
+	e3:SetCategory(CATEGORY_DESTROY)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_TO_DECK)
+	e3:SetCondition(c95519486.descon2)
+	e3:SetTarget(c95519486.destg)
+	e3:SetOperation(c95519486.desop)
+	c:RegisterEffect(e3)
+end
+function c95519486.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x103d) and not c:IsCode(95519486)
+end
+function c95519486.descon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dsercon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler()==Duel.GetAttacker() and Duel.GetAttackTarget()
+		and Duel.IsExistingMatchingCard(c95519486.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c95519486.descon2(e,tp,eg,ep,ev,re,r,rp)
+	return aux.dsercon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler()==Duel.GetAttacker() and Duel.GetAttackTarget()
+		and Duel.IsExistingMatchingCard(c95519486.cfilter,tp,LOCATION_MZONE,0,1,nil) and e:GetHandler():IsReason(REASON_BATTLE)
+end
+function c95519486.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetAttackTarget():IsRelateToBattle() end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,Duel.GetAttackTarget(),1,0,0)
+end
+function c95519486.desop(e,tp,eg,ep,ev,re,r,rp)
+	local d=Duel.GetAttackTarget()
+	if d:IsRelateToBattle() then
+		Duel.Destroy(d,REASON_EFFECT)
+	end
+end
+function c95519486.repfilter(c,e)
+	return c:IsFaceup() and c:IsSetCard(0x103d)
+		and c:IsDestructable(e) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+end
+function c95519486.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsReason(REASON_REPLACE) and c:IsOnField() and c:IsFaceup()
+		and Duel.IsExistingMatchingCard(c95519486.repfilter,tp,LOCATION_MZONE,0,1,c,e) end
+	if Duel.SelectEffectYesNo(tp,c,96) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
+		local g=Duel.SelectMatchingCard(tp,c95519486.repfilter,tp,LOCATION_MZONE,0,1,1,c,e)
+		e:SetLabelObject(g:GetFirst())
+		g:GetFirst():SetStatus(STATUS_DESTROY_CONFIRMED,true)
+		return true
+	else return false end
+end
+function c95519486.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)
+	Duel.Destroy(tc,REASON_EFFECT+REASON_REPLACE)
+end

--- a/706/c96565487.lua
+++ b/706/c96565487.lua
@@ -1,0 +1,22 @@
+--ブリザード・ウォリアー
+---@param c Card
+function c96565487.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(96565487,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_DAMAGE_STEP_END)
+	e1:SetLabel(65703851) --相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
+	e1:SetCondition(aux.dserodcon)
+	e1:SetOperation(c96565487.operation)
+	c:RegisterEffect(e1)
+end
+function c96565487.operation(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetDecktopGroup(1-tp,1)
+	if g:GetCount()==0 then return end
+	Duel.ConfirmCards(tp,g)
+	local tc=g:GetFirst()
+	local opt=Duel.SelectOption(tp,aux.Stringid(96565487,1),aux.Stringid(96565487,2))
+	if opt==1 then
+		Duel.MoveSequence(tc,opt)
+	end
+end

--- a/706/c99735427.lua
+++ b/706/c99735427.lua
@@ -15,10 +15,10 @@ function c99735427.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c99735427.disop(e,tp,eg,ep,ev,re,r,rp)
-	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
-	-- 临时添加被武僧洗回卡组的反转效果无效
+	local loc,eff=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_EFFECT)
+	-- 临时添加被武僧洗回卡组的反转效果无效 相杀算场上发动统一使用透破拔卡片密码标记处理类透破拔条件
 	local c=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_EFFECT):GetHandler()
-	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0))
+	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0) or ((loc==LOCATION_GRAVE or loc==LOCATION_REMOVED) and eff:GetLabel()==65703851) )
 		and re:GetHandler():IsAttribute(ATTRIBUTE_DARK) then
 		Duel.NegateEffect(ev)
 	end

--- a/706/c99735427.lua
+++ b/706/c99735427.lua
@@ -1,0 +1,25 @@
+--暗闇を吸い込むマジック・ミラー
+---@param c Card
+function c99735427.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetOperation(c99735427.disop)
+	c:RegisterEffect(e2)
+end
+function c99735427.disop(e,tp,eg,ep,ev,re,r,rp)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	-- 临时添加被武僧洗回卡组的反转效果无效
+	local c=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_EFFECT):GetHandler()
+	if re:IsActiveType(TYPE_MONSTER) and (loc==LOCATION_MZONE or loc==LOCATION_GRAVE or (loc==LOCATION_DECK and c:GetFlagEffect(44178886)>0))
+		and re:GetHandler():IsAttribute(ATTRIBUTE_DARK) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/706/special.lua
+++ b/706/special.lua
@@ -80,7 +80,7 @@ function Auxiliary.PreloadUds()
 						if c:IsLocation(LOCATION_ONFIELD) and c:IsSummonType(SUMMON_TYPE_FLIP) and re~=nil and re:GetCode() == EVENT_FLIP_SUMMON and re:GetCategory()&CATEGORY_DISABLE_SUMMON ~= 0 then
 							return false
 						end
-						return old_condition == nil or old_condition(e2,tp2,eg2,ep2,ev2,re2,r2,rp2)
+                        return old_condition == nil or old_condition(e2,tp2,eg2,ep2,ev2,re2,r2,rp2)
 					end)
 				end
 			end
@@ -102,3 +102,10 @@ function Auxiliary.PreloadUds()
     end
 
 end	
+
+--condition of EVENT_DAMAGE_STEP_END + this monster is releate to battle + opponent monster destroyed by battle
+function Auxiliary.dserodcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return bc~=nil and bc:IsReason(REASON_BATTLE)
+end


### PR DESCRIPTION
1、[光道武僧（44178886）洗回光或者暗属性反转怪且场上有吸入闪光的魔镜（53341729）、吸入阴暗的魔镜（99735427）时，那个反转怪的效果应该被无效](https://github.com/purerosefallen/specials/commit/60e4f1b92d2529864a38f6c634a71c30785c3114)

2、[修改光道武僧（44178886）打表侧反转怪依旧卡组发效果的bug，给六武众斩次（95519486）临时增加效果以还原被人鱼打回卡组依旧能发破坏效果的旧裁定](https://github.com/purerosefallen/specials/commit/13f7dcfd8d7cf32f06296fc3e6f28920e9a668c4)

3、[修复“装备怪兽战斗破坏对方怪兽”描述的卡片在装备怪兽控制权转移后不应抽卡的bug，本次涉及的卡片有D-锁链（43405287）、汽油侠（31768112）、剑之辉煌（48447192）、身剑一体（6112401）、新宇之力（47274077）、水压加农炮（12174035）、破坏炮击人（63676256）、六武众的御灵代（65685470）、大日超立方体（84313685）、幻兽之角（61350571）、三角火龙（48568432）、大日五胞体（47228077）](https://github.com/purerosefallen/specials/commit/c0b5334c5d4d2d82707465adb7a4c714d96bb0ef) 

4、[混沌无限同时翻开幻想召唤师跟肿头龙的时候，幻想召唤师（14644902）解放肿头龙应该可以正常特招](https://github.com/purerosefallen/specials/commit/d94bf06bd7fbb90e4cb484eccaf9eb6c05a198d8)

5、[批量近似还原53张卡“战斗破坏对方怪兽时”描述的效果在跟对方怪兽相杀后也依旧可以在墓地或除外区发动效果且这个效果视为在场上发动的旧裁定，包括三角三（12079734）、胜利蛇XX03（93130021）、朱罗纪瓜巴龙（11012887）、静寂之圣者（26669055）、新炎狱萨满（39761138）、地缚神 卡帕克·阿普（46263076）、斯芬克斯·迪蕾雅（51402177）、圣兽 塞勒凯特（89194033）、古代的机械巨龙（50933533）、巨脑怪（17313545）、古代的机械合成兽（86321248）、异虫战神（35638627）、铠装念动力人（62742651）、蔷薇藤蔓（41160533）、大和神（82841979）、异虫王子（54860010）、时间吞噬者（44913552）、最终念动力食人魔（87622767）、暗黑骑士 珀耳修斯（76925842）、神龙-艾克塞利翁（10032958）、暗黑英雄 尸魔侠（88472456）、核成双刀手（80367387）、进化龙·角鼻龙（80651316）、核成十字军（32314730）、战士猿（41098335）、小仙人掌斗士（74440055）、爬虫妖女·斯库拉（16909657）、最高战士（94538053）、熔岩战士（52786469）、秘仪之力7-战车（34568403）、蓝色雷电T45（14089428）、朱罗纪禽龙（71106375）、艺妓之影（84055227）、外星人猎手（62315111）、亚马逊训练生（89567993）、元素恶魔（23118924）、元素魔术师（65260293）、间谍蜘蛛（80637190）、平稳之贤者（62054060）、雪暴战士（96565487）、假面斩杀者（87350908）、芬里尔（218704）、电子暗黑龙骨（3019642）、罪 真实龙（37115575）、斯芬克斯·安德鲁（15013468）、XX-剑士 富勒姆奈特（78422252）、大刀β（86170989）、罗德不列颠号（35514096）、元素英雄 新星主（1945387）、极战机王 战神机人（54702678）、次世代热能人（6588580）、盟军·次世代三力人（52709508）、真次世代风筝（73483491）](https://github.com/purerosefallen/specials/commit/a1d765239b1bda699d520de474179d2c56880e24) 
