### PR TITLE
还原天空可以炸0的旧裁定及修改地灵神为源数前版本

### DIFF
--- a/706/c40044918.lua
+++ b/706/c40044918.lua
@@ -1,0 +1,74 @@
+--E・HERO エアーマン
+function c40044918.initial_effect(c)
+	--effect
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(40044918,0))
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c40044918.tg)
+	e1:SetOperation(c40044918.op)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e2)
+end
+function c40044918.ctfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x8)
+end
+function c40044918.schfilter(c)
+	return c:IsSetCard(0x8) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c40044918.desfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c40044918.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then
+		local ct=Duel.GetMatchingGroupCount(c40044918.ctfilter,tp,LOCATION_MZONE,0,c)
+		local sel=0
+		if ct>0 and Duel.IsExistingMatchingCard(c40044918.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) then sel=sel+1 end
+		if Duel.IsExistingMatchingCard(c40044918.schfilter,tp,LOCATION_DECK,0,1,nil) then sel=sel+2 end
+		e:SetLabel(sel)
+		return sel~=0
+	end
+	local sel=e:GetLabel()
+	if sel==3 then
+		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(40044918,0))
+		sel=Duel.SelectOption(tp,aux.Stringid(40044918,1),aux.Stringid(40044918,2))+1
+	elseif sel==1 then
+		Duel.SelectOption(tp,aux.Stringid(40044918,1))
+	else
+		Duel.SelectOption(tp,aux.Stringid(40044918,2))
+	end
+	e:SetLabel(sel)
+	if sel==1 then
+		local g=Duel.GetMatchingGroup(c40044918.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+		e:SetCategory(CATEGORY_DESTROY)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,0,0,0)
+	else
+		e:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+		Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+	end
+end
+function c40044918.op(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local sel=e:GetLabel()
+	if sel==1 then
+		local ct=Duel.GetMatchingGroupCount(c40044918.ctfilter,tp,LOCATION_MZONE,0,c)
+		local g=Duel.GetMatchingGroup(c40044918.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+		if ct>0 and g:GetCount()>0 then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+			local dg=g:Select(tp,0,ct,nil)
+			Duel.HintSelection(dg)
+			Duel.Destroy(dg,REASON_EFFECT)
+		end
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+		local g=Duel.SelectMatchingCard(tp,c40044918.schfilter,tp,LOCATION_DECK,0,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.SendtoHand(g,nil,REASON_EFFECT)
+			Duel.ConfirmCards(1-tp,g)
+		end
+	end
+end

--- a/706/c61468779.lua
+++ b/706/c61468779.lua
@@ -1,0 +1,77 @@
+--地霊神グランソイル
+function c61468779.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c61468779.spcon)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(61468779,0))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetTarget(c61468779.sptg)
+	e3:SetOperation(c61468779.spop)
+	c:RegisterEffect(e3)
+	--leave
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetOperation(c61468779.leaveop)
+	c:RegisterEffect(e4)
+end
+function c61468779.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
+		Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_EARTH)==5
+end
+function c61468779.filter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c61468779.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and c61468779.filter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c61468779.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c61468779.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c61468779.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c61468779.leaveop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	if Duel.GetTurnPlayer()==effp then
+		e1:SetLabel(Duel.GetTurnCount())
+		e1:SetCondition(c61468779.skipcon)
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+	else
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,1)
+	end
+	Duel.RegisterEffect(e1,effp)
+end
+function c61468779.skipcon(e)
+	return Duel.GetTurnCount()~=e:GetLabel()
+end


### PR DESCRIPTION
1、元素英雄 天空侠（40044918）的魔陷破坏效果在效果处理时还原为可以选择炸0的旧裁定，因而不能对应其连锁星尘龙（44508094）、流星龙（24696097）、六尺琼勾玉（41458579）的效果

2、地灵神 格兰索尔（61468779）的效果还原为源数前版本